### PR TITLE
chore: pin Codex CLI version and add Renovate auto-update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apk add --no-cache git ca-certificates
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --prod --frozen-lockfile
-RUN npm install -g @openai/codex@latest
+# renovate: datasource=npm depName=@openai/codex
+RUN npm install -g @openai/codex@0.112.0
 
 COPY --from=build /app/dist ./dist
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=npm depName=@openai/codex\\nRUN npm install -g @openai/codex@(?<currentValue>[\\d.]+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@openai/codex"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["@openai/codex"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["@openai/codex"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/",
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Dockerfile: `@openai/codex@latest` → `@0.112.0` 고정 (deterministic builds)
- `renovate.json` 추가: npm datasource로 새 stable 버전 감지 시 자동 PR 생성
- alpha/platform-specific 태그 제외 (`allowedVersions: /^\d+\.\d+\.\d+$/`)

## Test plan
- [x] `docker build --target runtime` 빌드 성공
- [ ] Renovate GitHub App 설치 후 자동 감지 확인