### PR TITLE
feat: auto review trigger on PR open/update

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -4,6 +4,20 @@
 
 ## 완료된 작업
 
+### Task 5: PR 오픈 시 자동 리뷰/서머리 트리거
+- **상태**: ✅ 완료
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| IBitbucketWebhookBase 추출 + IBitbucketPrWebhook 추가 | ✅ | webhook.interfaces.ts 리팩터 |
+| triggerCommentId optional 처리 | ✅ | queue + review 인터페이스 |
+| shouldAutoReview / shouldMentionReview | ✅ | trigger.service.ts 확장 |
+| WebhookController 이벤트 라우팅 | ✅ | handleCommentEvent + handlePrEvent + enqueueReview 추출 |
+| ReviewProcessor auto 에러 댓글 | ✅ | triggerCommentId 없을 때 createComment fallback |
+| TriggerService 테스트 | ✅ | shouldAutoReview 8케이스 + shouldMentionReview 3케이스 |
+| ReviewProcessor 에러 핸들링 테스트 | ✅ | auto/mention 분기 테스트 |
+| pnpm build + test | ✅ | 55 tests passed |
+
 ### Task 1: 구조화된 리뷰 출력 포맷
 - **파일**: `src/queue/review.types.ts`, `src/queue/review.formatter.ts`, `src/queue/review.processor.ts`
 - **상태**: ✅ 완료

--- a/README.md
+++ b/README.md
@@ -2,30 +2,29 @@
 
 > Bitbucket PR webhook → Codex CLI 자동 코드 리뷰 → PR 코멘트 게시
 
-Bitbucket PR에 `@codex` 멘션이 달리면 자동으로 코드 리뷰를 수행하고, 인라인 코멘트와 요약을 PR에 게시하는 워커 서비스.
+Bitbucket PR에 `@codex` 멘션 또는 PR 오픈/업데이트 시 자동으로 코드 리뷰를 수행하고, 인라인 코멘트와 요약을 PR에 게시하는 워커 서비스.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    A[Bitbucket Webhook] -->|PR comment| B[NestJS Server]
+    A[Bitbucket Webhook] -->|PR event / comment| B[NestJS Server]
     B -->|HMAC 검증| C{트리거 감지}
     C -->|"@codex 멘션"| D[BullMQ Job Queue]
+    C -->|"PR 오픈/업데이트 (auto)"| D
     D --> E[Git Worktree 생성]
-    E --> F1[Codex CLI: 요약]
-    E --> F2[Codex CLI: 상세 리뷰]
-    F1 --> G[Bitbucket API]
-    F2 --> G
+    E --> F[Codex CLI: 요약 + 상세 리뷰]
+    F --> G[Bitbucket API]
     G -->|inline comments + summary| A
 ```
 
 ## How It Works
 
-1. **Webhook 수신** — Bitbucket `pullrequest:comment_created` 이벤트 수신
-2. **트리거 감지** — `@codex` 멘션 감지 후 리뷰 작업 큐잉
+1. **Webhook 수신** — Bitbucket PR 이벤트 (`pullrequest:created`, `pullrequest:updated`, `pullrequest:comment_created`) 수신
+2. **트리거 감지** — 트리거 모드에 따라 자동(PR 오픈/업데이트) 또는 멘션(`@codex`) 기반으로 리뷰 작업 큐잉
 3. **Worktree 준비** — Bare repo clone + git worktree 생성 (PR head commit)
-4. **병렬 리뷰** — Codex CLI로 **요약** + **상세 리뷰** 병렬 실행
-5. **결과 게시** — 인라인 코멘트 + summary table로 Bitbucket PR에 게시
+4. **통합 리뷰** — Codex CLI로 **요약 + verdict + 상세 리뷰** 단일 호출
+5. **결과 게시** — verdict badge + 인라인 코멘트 + summary table로 Bitbucket PR에 게시
 
 ## Prerequisites
 
@@ -119,7 +118,18 @@ docker compose up -d
 | `BITBUCKET_BASE_URL` | Bitbucket API 기본 URL | `https://api.bitbucket.org/2.0` |
 | `BITBUCKET_API_TOKEN` | API 토큰 | - |
 | `BITBUCKET_WEBHOOK_SECRET` | Webhook HMAC secret | - |
-| `REVIEW_TRIGGER_MODE` | 트리거 모드 (`mention` / `auto` / `both`) | `mention` |
+| `REVIEW_TRIGGER_MODE` | 트리거 모드 (아래 참조) | `mention` |
+
+#### `REVIEW_TRIGGER_MODE` 상세
+
+| 모드 | PR 오픈/업데이트 시 | `@codex` 댓글 시 |
+|------|:---:|:---:|
+| `mention` (기본) | 무시 | 리뷰 실행 |
+| `auto` | 리뷰 실행 | 무시 |
+| `both` | 리뷰 실행 | 리뷰 실행 |
+
+> [!NOTE]
+> `auto`/`both` 모드에서 `pullrequest:updated` 이벤트도 처리됩니다. 동일 commit hash에 대한 중복 리뷰는 idempotency key로 자동 방지됩니다.
 
 ### Workspace
 

--- a/src/queue/interfaces/queue.interfaces.ts
+++ b/src/queue/interfaces/queue.interfaces.ts
@@ -13,5 +13,5 @@ export interface IReviewJobData {
   readonly cloneUrl: string;
   readonly idempotencyKey: string;
   readonly triggerType: TriggerType;
-  readonly triggerCommentId: number;
+  readonly triggerCommentId?: number;
 }

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -7,6 +7,19 @@ import {
   buildVerdictBadge,
 } from "./review.formatter";
 import { type IReviewItem } from "./review.types";
+import { ReviewProcessor } from "./review.processor";
+import { TriggerType } from "../entities/review-run.entity";
+import { IReviewJobData } from "./interfaces/queue.interfaces";
+
+jest.mock("@lib/logger", () => ({
+  ServiceLogger: jest.fn().mockImplementation(() => ({
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    verbose: jest.fn(),
+  })),
+}));
 
 describe("review.formatter", () => {
   describe("parseReviewItems", () => {
@@ -399,5 +412,99 @@ describe("review.formatter", () => {
 
       expect(result).toBe("💬 **Comment** (confidence: 50%)");
     });
+  });
+});
+
+describe("ReviewProcessor error handling", () => {
+  const mockReviewService = {
+    updateStatus: jest.fn(),
+    existsByIdempotencyKey: jest.fn(),
+    createReviewRun: jest.fn(),
+    supersedeActivePrReviews: jest.fn(),
+  };
+  const mockWorkspaceService = {
+    prepareWorktree: jest.fn(),
+    cleanupWorktree: jest.fn(),
+  };
+  const mockCodexService = {
+    executeCodex: jest.fn(),
+  };
+  const mockBitbucketService = {
+    createComment: jest.fn().mockResolvedValue({ id: 100 }),
+    replyToComment: jest.fn().mockResolvedValue({ id: 101 }),
+    createInlineComment: jest.fn().mockResolvedValue({ id: 102 }),
+  };
+
+  let processor: ReviewProcessor;
+
+  const baseJobData: IReviewJobData = {
+    reviewRunId: 1,
+    repositorySlug: "my-repo",
+    workspaceSlug: "my-workspace",
+    pullRequestId: 42,
+    headCommitHash: "abc1234",
+    baseCommitHash: "def5678",
+    baseBranch: "main",
+    headBranch: "feature/test",
+    cloneUrl: "https://bitbucket.org/my-workspace/my-repo.git",
+    idempotencyKey: "my-repo:42:abc1234",
+    triggerType: TriggerType.MENTION,
+    triggerCommentId: 999,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    processor = new ReviewProcessor(
+      mockReviewService as never,
+      mockWorkspaceService as never,
+      mockCodexService as never,
+      mockBitbucketService as never,
+    );
+  });
+
+  it("should replyToComment when triggerCommentId is present", async () => {
+    mockWorkspaceService.prepareWorktree.mockRejectedValue(
+      new Error("workspace error"),
+    );
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+
+    const job = { data: { ...baseJobData, triggerCommentId: 999 } } as never;
+
+    await expect(processor.process(job)).rejects.toThrow("workspace error");
+
+    expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentCommentId: 999,
+        body: expect.stringContaining("Code Review 실패"),
+      }),
+    );
+    expect(mockBitbucketService.createComment).not.toHaveBeenCalled();
+  });
+
+  it("should createComment when triggerCommentId is undefined (auto trigger)", async () => {
+    mockWorkspaceService.prepareWorktree.mockRejectedValue(
+      new Error("workspace error"),
+    );
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+
+    const job = {
+      data: {
+        ...baseJobData,
+        triggerType: TriggerType.AUTO,
+        triggerCommentId: undefined,
+      },
+    } as never;
+
+    await expect(processor.process(job)).rejects.toThrow("workspace error");
+
+    expect(mockBitbucketService.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: "my-workspace",
+        repoSlug: "my-repo",
+        pullRequestId: 42,
+        body: expect.stringContaining("Code Review 실패"),
+      }),
+    );
+    expect(mockBitbucketService.replyToComment).not.toHaveBeenCalled();
   });
 });

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -66,7 +66,8 @@ export class ReviewProcessor extends WorkerHost {
         },
       );
 
-      // Notify user on the original @codex comment
+      // Notify user about the failure
+      const errorBody = `❌ Code Review 실패\n\n\`\`\`\n${error.message.substring(0, 500)}\n\`\`\``;
       if (data.triggerCommentId) {
         this.bitbucketService
           .replyToComment({
@@ -74,11 +75,24 @@ export class ReviewProcessor extends WorkerHost {
             repoSlug: data.repositorySlug,
             pullRequestId: data.pullRequestId,
             parentCommentId: data.triggerCommentId,
-            body: `❌ Code Review 실패\n\n\`\`\`\n${error.message.substring(0, 500)}\n\`\`\``,
+            body: errorBody,
           })
           .catch((replyErr) => {
             this.logger.error(
               `Failed to post error reply: ${(replyErr as Error).message}`,
+            );
+          });
+      } else {
+        this.bitbucketService
+          .createComment({
+            workspace: data.workspaceSlug,
+            repoSlug: data.repositorySlug,
+            pullRequestId: data.pullRequestId,
+            body: errorBody,
+          })
+          .catch((commentErr) => {
+            this.logger.error(
+              `Failed to post error comment: ${(commentErr as Error).message}`,
             );
           });
       }

--- a/src/review/interfaces/review.interfaces.ts
+++ b/src/review/interfaces/review.interfaces.ts
@@ -5,5 +5,5 @@ import { IWebhookPrPayload } from "../../webhook/interfaces/webhook.interfaces";
 export interface ICreateReviewRunParams extends IWebhookPrPayload {
   readonly idempotencyKey: string;
   readonly triggerType: TriggerType;
-  readonly triggerCommentId: number;
+  readonly triggerCommentId?: number;
 }

--- a/src/webhook/interfaces/webhook.interfaces.ts
+++ b/src/webhook/interfaces/webhook.interfaces.ts
@@ -10,18 +10,8 @@ export interface IWebhookPrPayload {
   readonly cloneUrl: string;
 }
 
-/** 댓글 웹훅 페이로드 (Bitbucket pullrequest:comment_created) */
-export interface IBitbucketCommentWebhook {
-  readonly comment: {
-    readonly id: number;
-    readonly content: {
-      readonly raw: string;
-    };
-    readonly user: {
-      readonly uuid: string;
-      readonly display_name: string;
-    };
-  };
+/** 공통 웹훅 base (pullrequest + repository) */
+export interface IBitbucketWebhookBase {
   readonly pullrequest: {
     readonly id: number;
     readonly title: string;
@@ -54,3 +44,20 @@ export interface IBitbucketCommentWebhook {
     };
   };
 }
+
+/** 댓글 웹훅 페이로드 (Bitbucket pullrequest:comment_created) */
+export interface IBitbucketCommentWebhook extends IBitbucketWebhookBase {
+  readonly comment: {
+    readonly id: number;
+    readonly content: {
+      readonly raw: string;
+    };
+    readonly user: {
+      readonly uuid: string;
+      readonly display_name: string;
+    };
+  };
+}
+
+/** PR 이벤트 웹훅 (pullrequest:created, pullrequest:updated) */
+export type IBitbucketPrWebhook = IBitbucketWebhookBase;

--- a/src/webhook/trigger.service.spec.ts
+++ b/src/webhook/trigger.service.spec.ts
@@ -42,4 +42,32 @@ describe("TriggerService", () => {
   it("should return false for partial match like @codex-bot", () => {
     expect(service.hasCodexMention("@codex-bot")).toBe(false);
   });
+
+  describe("shouldAutoReview", () => {
+    it.each([
+      ["pullrequest:created", "auto", true],
+      ["pullrequest:updated", "auto", true],
+      ["pullrequest:created", "both", true],
+      ["pullrequest:updated", "both", true],
+      ["pullrequest:created", "mention", false],
+      ["pullrequest:updated", "mention", false],
+      ["pullrequest:comment_created", "auto", false],
+      ["pullrequest:comment_created", "both", false],
+    ])(
+      "event=%s, mode=%s → %s",
+      (eventKey, triggerMode, expected) => {
+        expect(service.shouldAutoReview(eventKey, triggerMode)).toBe(expected);
+      },
+    );
+  });
+
+  describe("shouldMentionReview", () => {
+    it.each([
+      ["mention", true],
+      ["both", true],
+      ["auto", false],
+    ])("mode=%s → %s", (triggerMode, expected) => {
+      expect(service.shouldMentionReview(triggerMode)).toBe(expected);
+    });
+  });
 });

--- a/src/webhook/trigger.service.ts
+++ b/src/webhook/trigger.service.ts
@@ -15,4 +15,18 @@ export class TriggerService {
     );
     return result;
   }
+
+  /** PR 이벤트에서 자동 리뷰를 트리거해야 하는지 확인 */
+  shouldAutoReview(eventKey: string, triggerMode: string): boolean {
+    const autoEvents = ["pullrequest:created", "pullrequest:updated"];
+    return (
+      autoEvents.includes(eventKey) &&
+      (triggerMode === "auto" || triggerMode === "both")
+    );
+  }
+
+  /** 댓글 멘션 트리거가 활성화되어 있는지 확인 */
+  shouldMentionReview(triggerMode: string): boolean {
+    return triggerMode === "mention" || triggerMode === "both";
+  }
 }

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -17,6 +17,8 @@ import { TriggerService } from "./trigger.service";
 import { WebhookGuard } from "./webhook.guard";
 import {
   IBitbucketCommentWebhook,
+  IBitbucketPrWebhook,
+  IBitbucketWebhookBase,
   IWebhookPrPayload,
 } from "./interfaces/webhook.interfaces";
 import { TriggerType } from "../entities/review-run.entity";
@@ -40,70 +42,49 @@ export class WebhookController {
   @HttpCode(HttpStatus.ACCEPTED)
   @UseGuards(WebhookGuard)
   async handleBitbucketWebhook(
-    @Body() body: IBitbucketCommentWebhook,
+    @Body() body: IBitbucketWebhookBase,
     @Headers("x-event-key") eventKey: string,
   ): Promise<{ accepted: boolean; reason?: string }> {
-    if (eventKey !== "pullrequest:comment_created") {
-      return { accepted: false, reason: `Ignored event: ${eventKey}` };
+    const triggerMode = this.configService.get<string>(
+      "trigger.mode",
+      "mention",
+    );
+
+    if (eventKey === "pullrequest:comment_created") {
+      return this.handleCommentEvent(
+        body as IBitbucketCommentWebhook,
+        triggerMode,
+      );
     }
 
+    if (this.triggerService.shouldAutoReview(eventKey, triggerMode)) {
+      return this.handlePrEvent(body as IBitbucketPrWebhook);
+    }
+
+    return { accepted: false, reason: `Ignored event: ${eventKey}` };
+  }
+
+  /** 댓글 이벤트 처리 (@codex 멘션 트리거) */
+  private async handleCommentEvent(
+    body: IBitbucketCommentWebhook,
+    triggerMode: string,
+  ): Promise<{ accepted: boolean; reason?: string }> {
     if (!body.comment?.id || !body.comment?.content?.raw) {
       throw new BadRequestException(
         "Missing required fields: comment.id, comment.content.raw",
       );
     }
 
-    const triggerMode = this.configService.get<string>(
-      "trigger.mode",
-      "mention",
-    );
-    const commentRaw = body.comment.content.raw;
-
     if (
-      triggerMode === "mention" &&
-      !this.triggerService.hasCodexMention(commentRaw)
+      !this.triggerService.shouldMentionReview(triggerMode) ||
+      !this.triggerService.hasCodexMention(body.comment.content.raw)
     ) {
       return { accepted: false, reason: "No @codex mention found" };
     }
 
     const prPayload = this.extractPrPayload(body);
-    const idempotencyKey = `${prPayload.repositorySlug}:${prPayload.pullRequestId}:${prPayload.headCommitHash}`;
 
-    const isDuplicate =
-      await this.reviewService.existsByIdempotencyKey(idempotencyKey);
-    if (isDuplicate) {
-      this.logger.log(`Duplicate review request skipped: ${idempotencyKey}`);
-      return { accepted: false, reason: "Duplicate request" };
-    }
-
-    // Remove stale BullMQ job if it exists (e.g. from a previous failed attempt)
-    try {
-      const existingJob = await this.reviewQueue.getJob(idempotencyKey);
-      if (existingJob) {
-        await existingJob.remove();
-        this.logger.log(`Removed stale BullMQ job: ${idempotencyKey}`);
-      }
-    } catch (err) {
-      this.logger.error(
-        `Failed to remove stale job: ${(err as Error).message}`,
-      );
-    }
-
-    const reviewRun = await this.reviewService.createReviewRun({
-      ...prPayload,
-      idempotencyKey,
-      triggerType: TriggerType.MENTION,
-      triggerCommentId: body.comment.id,
-    });
-
-    // Supersede any active reviews for the same PR (e.g. new commit pushed)
-    await this.reviewService.supersedeActivePrReviews(
-      prPayload.repositorySlug,
-      prPayload.pullRequestId,
-      reviewRun.id,
-    );
-
-    // Post immediate "in progress" reply so the user knows the bot received the request
+    // Post immediate "in progress" reply
     const model = this.configService.getOrThrow<string>("codex.model");
     const reasoningEffort = this.configService.get<string>(
       "codex.reasoningEffort",
@@ -122,16 +103,96 @@ export class WebhookController {
       })
       .catch((err) => {
         this.logger.error(
-          `Failed to post in-progress reply: ${err.message}`,
+          `Failed to post in-progress reply: ${(err as Error).message}`,
         );
       });
+
+    return this.enqueueReview(
+      prPayload,
+      TriggerType.MENTION,
+      body.comment.id,
+    );
+  }
+
+  /** PR 이벤트 처리 (자동 트리거) */
+  private async handlePrEvent(
+    body: IBitbucketPrWebhook,
+  ): Promise<{ accepted: boolean; reason?: string }> {
+    const prPayload = this.extractPrPayload(body);
+
+    // Post immediate "in progress" top-level comment
+    const model = this.configService.getOrThrow<string>("codex.model");
+    const reasoningEffort = this.configService.get<string>(
+      "codex.reasoningEffort",
+      "",
+    );
+    const reasoningLine = reasoningEffort
+      ? `\n- Reasoning: ${reasoningEffort}`
+      : "";
+    this.bitbucketService
+      .createComment({
+        workspace: prPayload.workspaceSlug,
+        repoSlug: prPayload.repositorySlug,
+        pullRequestId: prPayload.pullRequestId,
+        body: `⏳ Summary & Code Review 진행 중...\n\n- Model: ${model}${reasoningLine}`,
+      })
+      .catch((err) => {
+        this.logger.error(
+          `Failed to post in-progress comment: ${(err as Error).message}`,
+        );
+      });
+
+    return this.enqueueReview(prPayload, TriggerType.AUTO);
+  }
+
+  /** 공통: idempotency 체크 + stale job 제거 + DB 생성 + supersede + 큐 등록 */
+  private async enqueueReview(
+    prPayload: IWebhookPrPayload,
+    triggerType: TriggerType,
+    triggerCommentId?: number,
+  ): Promise<{ accepted: boolean; reason?: string }> {
+    const idempotencyKey = `${prPayload.repositorySlug}:${prPayload.pullRequestId}:${prPayload.headCommitHash}`;
+
+    const isDuplicate =
+      await this.reviewService.existsByIdempotencyKey(idempotencyKey);
+    if (isDuplicate) {
+      this.logger.log(`Duplicate review request skipped: ${idempotencyKey}`);
+      return { accepted: false, reason: "Duplicate request" };
+    }
+
+    // Remove stale BullMQ job if it exists
+    try {
+      const existingJob = await this.reviewQueue.getJob(idempotencyKey);
+      if (existingJob) {
+        await existingJob.remove();
+        this.logger.log(`Removed stale BullMQ job: ${idempotencyKey}`);
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to remove stale job: ${(err as Error).message}`,
+      );
+    }
+
+    const reviewRun = await this.reviewService.createReviewRun({
+      ...prPayload,
+      idempotencyKey,
+      triggerType,
+      triggerCommentId,
+    });
+
+    // Supersede any active reviews for the same PR
+    await this.reviewService.supersedeActivePrReviews(
+      prPayload.repositorySlug,
+      prPayload.pullRequestId,
+      reviewRun.id,
+    );
 
     const jobData: IReviewJobData = {
       reviewRunId: reviewRun.id,
       ...prPayload,
       idempotencyKey,
-      triggerType: TriggerType.MENTION,
-      triggerCommentId: body.comment.id,
+      triggerType,
+      triggerCommentId,
     };
 
     await this.reviewQueue.add("review", jobData, {
@@ -145,7 +206,7 @@ export class WebhookController {
     return { accepted: true };
   }
 
-  private extractPrPayload(body: IBitbucketCommentWebhook): IWebhookPrPayload {
+  private extractPrPayload(body: IBitbucketWebhookBase): IWebhookPrPayload {
     // Validate required nested fields
     if (!body.pullrequest?.id || !body.pullrequest?.source?.commit?.hash) {
       throw new BadRequestException(

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -84,34 +84,17 @@ export class WebhookController {
 
     const prPayload = this.extractPrPayload(body);
 
-    // Post immediate "in progress" reply
-    const model = this.configService.getOrThrow<string>("codex.model");
-    const reasoningEffort = this.configService.get<string>(
-      "codex.reasoningEffort",
-      "",
-    );
-    const reasoningLine = reasoningEffort
-      ? `\n- Reasoning: ${reasoningEffort}`
-      : "";
-    this.bitbucketService
-      .replyToComment({
-        workspace: prPayload.workspaceSlug,
-        repoSlug: prPayload.repositorySlug,
-        pullRequestId: prPayload.pullRequestId,
-        parentCommentId: body.comment.id,
-        body: `⏳ Summary & Code Review 진행 중...\n\n- Model: ${model}${reasoningLine}`,
-      })
-      .catch((err) => {
-        this.logger.error(
-          `Failed to post in-progress reply: ${(err as Error).message}`,
-        );
-      });
-
-    return this.enqueueReview(
+    const result = await this.enqueueReview(
       prPayload,
       TriggerType.MENTION,
       body.comment.id,
     );
+
+    if (result.accepted) {
+      this.postInProgressReply(prPayload, body.comment.id);
+    }
+
+    return result;
   }
 
   /** PR 이벤트 처리 (자동 트리거) */
@@ -120,29 +103,13 @@ export class WebhookController {
   ): Promise<{ accepted: boolean; reason?: string }> {
     const prPayload = this.extractPrPayload(body);
 
-    // Post immediate "in progress" top-level comment
-    const model = this.configService.getOrThrow<string>("codex.model");
-    const reasoningEffort = this.configService.get<string>(
-      "codex.reasoningEffort",
-      "",
-    );
-    const reasoningLine = reasoningEffort
-      ? `\n- Reasoning: ${reasoningEffort}`
-      : "";
-    this.bitbucketService
-      .createComment({
-        workspace: prPayload.workspaceSlug,
-        repoSlug: prPayload.repositorySlug,
-        pullRequestId: prPayload.pullRequestId,
-        body: `⏳ Summary & Code Review 진행 중...\n\n- Model: ${model}${reasoningLine}`,
-      })
-      .catch((err) => {
-        this.logger.error(
-          `Failed to post in-progress comment: ${(err as Error).message}`,
-        );
-      });
+    const result = await this.enqueueReview(prPayload, TriggerType.AUTO);
 
-    return this.enqueueReview(prPayload, TriggerType.AUTO);
+    if (result.accepted) {
+      this.postInProgressComment(prPayload);
+    }
+
+    return result;
   }
 
   /** 공통: idempotency 체크 + stale job 제거 + DB 생성 + supersede + 큐 등록 */
@@ -204,6 +171,54 @@ export class WebhookController {
     );
 
     return { accepted: true };
+  }
+
+  private buildProgressMessage(): string {
+    const model = this.configService.getOrThrow<string>("codex.model");
+    const reasoningEffort = this.configService.get<string>(
+      "codex.reasoningEffort",
+      "",
+    );
+    const reasoningLine = reasoningEffort
+      ? `\n- Reasoning: ${reasoningEffort}`
+      : "";
+    return `⏳ Summary & Code Review 진행 중...\n\n- Model: ${model}${reasoningLine}`;
+  }
+
+  /** Fire-and-forget: reply to trigger comment */
+  private postInProgressReply(
+    prPayload: IWebhookPrPayload,
+    parentCommentId: number,
+  ): void {
+    this.bitbucketService
+      .replyToComment({
+        workspace: prPayload.workspaceSlug,
+        repoSlug: prPayload.repositorySlug,
+        pullRequestId: prPayload.pullRequestId,
+        parentCommentId,
+        body: this.buildProgressMessage(),
+      })
+      .catch((err) => {
+        this.logger.error(
+          `Failed to post in-progress reply: ${(err as Error).message}`,
+        );
+      });
+  }
+
+  /** Fire-and-forget: top-level in-progress comment */
+  private postInProgressComment(prPayload: IWebhookPrPayload): void {
+    this.bitbucketService
+      .createComment({
+        workspace: prPayload.workspaceSlug,
+        repoSlug: prPayload.repositorySlug,
+        pullRequestId: prPayload.pullRequestId,
+        body: this.buildProgressMessage(),
+      })
+      .catch((err) => {
+        this.logger.error(
+          `Failed to post in-progress comment: ${(err as Error).message}`,
+        );
+      });
   }
 
   private extractPrPayload(body: IBitbucketWebhookBase): IWebhookPrPayload {


### PR DESCRIPTION
## Summary
- PR 오픈/업데이트 시 자동 코드 리뷰 트리거 기능 추가
- `REVIEW_TRIGGER_MODE` 설정: `mention` (기본), `auto` (PR 이벤트), `both` (양쪽 모두)
- WebhookController 이벤트 라우팅 리팩터링 + 공통 `enqueueReview()` 추출

## Changes
- `webhook.interfaces.ts`: `IBitbucketWebhookBase` 추출, `IBitbucketPrWebhook` 추가
- `trigger.service.ts`: `shouldAutoReview()`, `shouldMentionReview()` 추가
- `webhook.controller.ts`: 이벤트 라우터 + `handleCommentEvent` / `handlePrEvent` / `enqueueReview` 분리
- `review.processor.ts`: auto 트리거 실패 시 `createComment` fallback
- `queue.interfaces.ts`, `review.interfaces.ts`: `triggerCommentId` optional 처리
- `README.md`: 트리거 모드 상세 테이블 추가

## Test plan
- [x] `pnpm build` 성공
- [x] `pnpm test` 55 tests passed (13 신규)
- [ ] 수동: `REVIEW_TRIGGER_MODE=auto` → PR 오픈 시 자동 리뷰 확인
- [ ] 수동: `REVIEW_TRIGGER_MODE=mention` → PR 오픈 시 무시, `@codex` 멘션만 반응
- [ ] 수동: `REVIEW_TRIGGER_MODE=both` → 양쪽 모두 반응