### PR TITLE
feat: per-repository Bitbucket access tokens

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,8 +1,19 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-04-06
+> 마지막 업데이트: 2026-04-08
 
 ## 진행 중/최근 작업
+
+### Task 13: Per-Repository Bitbucket Token 지원
+- **상태**: ✅ 완료
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| configuration.ts 수정 | ✅ | `BITBUCKET_REPO_TOKENS` JSON 파싱 → `bitbucket.repoTokens` |
+| validation.ts 수정 | ✅ | Joi 스키마에 `BITBUCKET_REPO_TOKENS` 추가 |
+| BitbucketService 수정 | ✅ | 생성자 고정 authHeader → `resolveAuthHeader(repoSlug)` 런타임 lookup |
+| WorkspaceService 수정 | ✅ | `buildGitAuthEnv(repoSlug)` 파라미터 추가, repo별 토큰 우선 사용 |
+| 빌드/린트/테스트 통과 | ✅ | 69 tests passed |
 
 ### Task 12: Docker runtime curl 추가
 - **상태**: ✅ 완료

--- a/src/bitbucket/bitbucket.service.spec.ts
+++ b/src/bitbucket/bitbucket.service.spec.ts
@@ -1,0 +1,133 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { BitbucketService } from "./bitbucket.service";
+
+describe("BitbucketService", () => {
+  const createService = async (
+    configOverrides: Record<string, unknown> = {},
+  ): Promise<BitbucketService> => {
+    const defaults: Record<string, unknown> = {
+      "bitbucket.baseUrl": "https://api.bitbucket.org/2.0",
+      "bitbucket.repoTokens": {},
+      "bitbucket.apiToken": "",
+      "bitbucket.username": "",
+      "bitbucket.appPassword": "",
+      ...configOverrides,
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BitbucketService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: unknown) => {
+              return key in defaults ? defaults[key] : defaultValue;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    return module.get<BitbucketService>(BitbucketService);
+  };
+
+  describe("resolveAuthHeader (via createComment)", () => {
+    const mockFetch = (authHeaderCapture: string[]) => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 1 }),
+      });
+      const originalFetch = global.fetch as jest.Mock;
+      originalFetch.mockImplementation(
+        (_url: string, options: RequestInit) => {
+          const auth = (options.headers as Record<string, string>)[
+            "Authorization"
+          ];
+          authHeaderCapture.push(auth);
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ id: 1 }),
+          });
+        },
+      );
+    };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const commentParams = {
+      workspace: "my-workspace",
+      repoSlug: "my-repo",
+      pullRequestId: 1,
+      body: "test",
+    };
+
+    it("uses repo-specific token when available", async () => {
+      const service = await createService({
+        "bitbucket.repoTokens": { "my-repo": "repo-token-123" },
+        "bitbucket.apiToken": "global-token",
+      });
+      const captured: string[] = [];
+      mockFetch(captured);
+
+      await service.createComment(commentParams);
+
+      expect(captured[0]).toBe("Bearer repo-token-123");
+    });
+
+    it("falls back to global apiToken when no repo token", async () => {
+      const service = await createService({
+        "bitbucket.repoTokens": { "other-repo": "other-token" },
+        "bitbucket.apiToken": "global-token",
+      });
+      const captured: string[] = [];
+      mockFetch(captured);
+
+      await service.createComment(commentParams);
+
+      expect(captured[0]).toBe("Bearer global-token");
+    });
+
+    it("falls back to Basic auth when no tokens exist", async () => {
+      const service = await createService({
+        "bitbucket.username": "myuser",
+        "bitbucket.appPassword": "mypass",
+      });
+      const captured: string[] = [];
+      mockFetch(captured);
+
+      await service.createComment(commentParams);
+
+      const expected = `Basic ${Buffer.from("myuser:mypass").toString("base64")}`;
+      expect(captured[0]).toBe(expected);
+    });
+
+    it("returns Basic header with empty creds when nothing configured", async () => {
+      const service = await createService({});
+      const captured: string[] = [];
+      mockFetch(captured);
+
+      await service.createComment(commentParams);
+
+      const expected = `Basic ${Buffer.from(":").toString("base64")}`;
+      expect(captured[0]).toBe(expected);
+    });
+
+    it("prefers repo token over all other auth methods", async () => {
+      const service = await createService({
+        "bitbucket.repoTokens": { "my-repo": "repo-specific" },
+        "bitbucket.apiToken": "global-api-token",
+        "bitbucket.username": "user",
+        "bitbucket.appPassword": "pass",
+      });
+      const captured: string[] = [];
+      mockFetch(captured);
+
+      await service.createComment(commentParams);
+
+      expect(captured[0]).toBe("Bearer repo-specific");
+    });
+  });
+});

--- a/src/bitbucket/bitbucket.service.ts
+++ b/src/bitbucket/bitbucket.service.ts
@@ -11,32 +11,40 @@ import {
 export class BitbucketService {
   private readonly logger = new ServiceLogger(BitbucketService.name);
   private readonly baseUrl: string;
-  private readonly authHeader: string;
 
   constructor(private readonly configService: ConfigService) {
     this.baseUrl = this.configService.get<string>(
       "bitbucket.baseUrl",
       "https://api.bitbucket.org/2.0",
     );
+  }
+
+  /** Resolve auth header: repoTokens[repoSlug] → apiToken → username/appPassword */
+  private resolveAuthHeader(repoSlug: string): string {
+    const repoTokens =
+      this.configService.get<Record<string, string>>("bitbucket.repoTokens") ??
+      {};
+    const repoToken = repoTokens[repoSlug];
+    if (repoToken) {
+      return `Bearer ${repoToken}`;
+    }
+
     const apiToken = this.configService.get<string>("bitbucket.apiToken", "");
     if (apiToken) {
-      this.authHeader = `Bearer ${apiToken}`;
-    } else {
-      const username = this.configService.get<string>(
-        "bitbucket.username",
-        "",
-      );
-      const appPassword = this.configService.get<string>(
-        "bitbucket.appPassword",
-        "",
-      );
-      if (!username || !appPassword) {
-        this.logger.warn(
-          "No Bitbucket auth configured — API calls will fail for private resources",
-        );
-      }
-      this.authHeader = `Basic ${Buffer.from(`${username}:${appPassword}`).toString("base64")}`;
+      return `Bearer ${apiToken}`;
     }
+
+    const username = this.configService.get<string>("bitbucket.username", "");
+    const appPassword = this.configService.get<string>(
+      "bitbucket.appPassword",
+      "",
+    );
+    if (!username || !appPassword) {
+      this.logger.warn(
+        `No Bitbucket auth configured for repo "${repoSlug}" — API calls will fail`,
+      );
+    }
+    return `Basic ${Buffer.from(`${username}:${appPassword}`).toString("base64")}`;
   }
 
   /** PR에 리뷰 결과 댓글 생성 */
@@ -48,7 +56,7 @@ export class BitbucketService {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: this.authHeader,
+        Authorization: this.resolveAuthHeader(params.repoSlug),
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -77,7 +85,7 @@ export class BitbucketService {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: this.authHeader,
+        Authorization: this.resolveAuthHeader(params.repoSlug),
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -103,7 +111,7 @@ export class BitbucketService {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: this.authHeader,
+        Authorization: this.resolveAuthHeader(params.repoSlug),
         "Content-Type": "application/json",
       },
       body: JSON.stringify({

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,0 +1,60 @@
+import { parseRepoTokens } from "./configuration";
+
+describe("parseRepoTokens", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns empty object for undefined", () => {
+    expect(parseRepoTokens(undefined)).toEqual({});
+  });
+
+  it("returns empty object for empty string", () => {
+    expect(parseRepoTokens("")).toEqual({});
+  });
+
+  it("parses valid JSON object", () => {
+    const input = '{"repo-a":"token-a","repo-b":"token-b"}';
+    expect(parseRepoTokens(input)).toEqual({
+      "repo-a": "token-a",
+      "repo-b": "token-b",
+    });
+  });
+
+  it("warns and returns empty object for invalid JSON", () => {
+    expect(parseRepoTokens("{invalid}")).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to parse BITBUCKET_REPO_TOKENS"),
+    );
+  });
+
+  it("warns and returns empty object for JSON array", () => {
+    expect(parseRepoTokens('["a","b"]')).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("not a JSON object"),
+    );
+  });
+
+  it("warns and returns empty object for JSON primitive", () => {
+    expect(parseRepoTokens('"just-a-string"')).toEqual({});
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("not a JSON object"),
+    );
+  });
+
+  it("skips non-string values", () => {
+    const input = '{"repo-a":"token-a","repo-b":123,"repo-c":null}';
+    expect(parseRepoTokens(input)).toEqual({ "repo-a": "token-a" });
+  });
+
+  it("does not warn for valid input", () => {
+    parseRepoTokens('{"repo":"token"}');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -24,11 +24,14 @@ export const DEFAULTS = {
 } as const;
 
 /** Parse BITBUCKET_REPO_TOKENS JSON into a Record<string, string> */
-function parseRepoTokens(raw: string | undefined): Record<string, string> {
+export function parseRepoTokens(raw: string | undefined): Record<string, string> {
   if (!raw) return {};
   try {
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      console.warn(
+        "[config] BITBUCKET_REPO_TOKENS is not a JSON object. Falling back to empty map.",
+      );
       return {};
     }
     const result: Record<string, string> = {};
@@ -38,7 +41,10 @@ function parseRepoTokens(raw: string | undefined): Record<string, string> {
       }
     }
     return result;
-  } catch {
+  } catch (error) {
+    console.warn(
+      `[config] Failed to parse BITBUCKET_REPO_TOKENS: ${(error as Error).message}. Falling back to empty map.`,
+    );
     return {};
   }
 }

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -23,6 +23,26 @@ export const DEFAULTS = {
   LOG_LEVEL: "info",
 } as const;
 
+/** Parse BITBUCKET_REPO_TOKENS JSON into a Record<string, string> */
+function parseRepoTokens(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return {};
+    }
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === "string") {
+        result[key] = value;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
 export default (): Record<string, unknown> => ({
   port: parseInt(process.env["PORT"] || String(DEFAULTS.PORT), 10),
   metricsPort: parseInt(process.env["METRICS_PORT"] || String(DEFAULTS.METRICS_PORT), 10),
@@ -60,6 +80,7 @@ export default (): Record<string, unknown> => ({
   bitbucket: {
     baseUrl: process.env["BITBUCKET_BASE_URL"] || DEFAULTS.BITBUCKET_BASE_URL,
     apiToken: process.env["BITBUCKET_API_TOKEN"] || "",
+    repoTokens: parseRepoTokens(process.env["BITBUCKET_REPO_TOKENS"]),
     username: process.env["BITBUCKET_USERNAME"] || "",
     appPassword: process.env["BITBUCKET_APP_PASSWORD"] || "",
     webhookSecret: process.env["BITBUCKET_WEBHOOK_SECRET"] || "",

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -29,7 +29,21 @@ export const validationSchema = Joi.object({
   CODEX_MODEL: Joi.string().default(DEFAULTS.CODEX_MODEL),
   BITBUCKET_BASE_URL: Joi.string().default(DEFAULTS.BITBUCKET_BASE_URL),
   BITBUCKET_API_TOKEN: Joi.string().allow("").default(""),
-  BITBUCKET_REPO_TOKENS: Joi.string().allow("").default(""),
+  BITBUCKET_REPO_TOKENS: Joi.string()
+    .allow("")
+    .default("")
+    .custom((value: string) => {
+      if (!value) return value;
+      try {
+        const parsed: unknown = JSON.parse(value);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new Error("must be a JSON object");
+        }
+        return value;
+      } catch (e) {
+        throw new Error(`Invalid BITBUCKET_REPO_TOKENS: ${(e as Error).message}`);
+      }
+    }),
   BITBUCKET_USERNAME: Joi.string().allow("").default(""),
   BITBUCKET_APP_PASSWORD: Joi.string().allow("").default(""),
   BITBUCKET_WEBHOOK_SECRET: Joi.string().allow("").default(""),

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -29,6 +29,7 @@ export const validationSchema = Joi.object({
   CODEX_MODEL: Joi.string().default(DEFAULTS.CODEX_MODEL),
   BITBUCKET_BASE_URL: Joi.string().default(DEFAULTS.BITBUCKET_BASE_URL),
   BITBUCKET_API_TOKEN: Joi.string().allow("").default(""),
+  BITBUCKET_REPO_TOKENS: Joi.string().allow("").default(""),
   BITBUCKET_USERNAME: Joi.string().allow("").default(""),
   BITBUCKET_APP_PASSWORD: Joi.string().allow("").default(""),
   BITBUCKET_WEBHOOK_SECRET: Joi.string().allow("").default(""),

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -170,9 +170,8 @@ export class WorkspaceService {
 
   /**
    * Build GIT_ASKPASS env to avoid embedding credentials in clone URLs.
-   * Creates a temporary shell script that responds to git's username/password prompts.
+   * Auth resolution order: repoTokens[repoSlug] → apiToken → username/appPassword.
    */
-  /** Resolve git auth: repoTokens[repoSlug] → apiToken → username/appPassword */
   private async buildGitAuthEnv(
     repoSlug: string,
   ): Promise<Record<string, string>> {

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -60,7 +60,7 @@ export class WorkspaceService {
     this.assertWithinBasePath(bareRepoPath);
     this.assertWithinBasePath(worktreePath);
 
-    const gitAuthEnv = await this.buildGitAuthEnv();
+    const gitAuthEnv = await this.buildGitAuthEnv(params.repositorySlug);
     try {
       await this.ensureBareRepo(bareRepoPath, params.cloneUrl, gitAuthEnv);
       await this.fetchLatest(bareRepoPath, gitAuthEnv);
@@ -172,7 +172,18 @@ export class WorkspaceService {
    * Build GIT_ASKPASS env to avoid embedding credentials in clone URLs.
    * Creates a temporary shell script that responds to git's username/password prompts.
    */
-  private async buildGitAuthEnv(): Promise<Record<string, string>> {
+  /** Resolve git auth: repoTokens[repoSlug] → apiToken → username/appPassword */
+  private async buildGitAuthEnv(
+    repoSlug: string,
+  ): Promise<Record<string, string>> {
+    const repoTokens =
+      this.configService.get<Record<string, string>>("bitbucket.repoTokens") ??
+      {};
+    const repoToken = repoTokens[repoSlug];
+    if (repoToken) {
+      return this.createAskpassEnv("x-token-auth", repoToken);
+    }
+
     const apiToken = this.configService.get<string>("bitbucket.apiToken", "");
     if (apiToken) {
       return this.createAskpassEnv("x-token-auth", apiToken);
@@ -185,7 +196,7 @@ export class WorkspaceService {
     );
     if (!username || !appPassword) {
       this.logger.warn(
-        "No Bitbucket auth configured — git clone may fail for private repos",
+        `No Bitbucket auth configured for repo "${repoSlug}" — git clone may fail`,
       );
       return {};
     }


### PR DESCRIPTION
## Summary

- Repository Access Token을 repo별로 매핑하여 사용할 수 있도록 `BITBUCKET_REPO_TOKENS` 환경변수 추가
- Lookup 순서: `repoTokens[repoSlug]` → `BITBUCKET_API_TOKEN` → `username/appPassword` (하위 호환)
- `BitbucketService`와 `WorkspaceService` 양쪽에서 동일한 fallback 체인 적용
- Joi validation에서 JSON 형식 검증 (기동 시 빠른 실패)
- 잘못된 JSON 파싱 시 경고 로그 추가
- `parseRepoTokens` + auth fallback 단위 테스트 추가 (82 tests total)

## Test plan

- [ ] `BITBUCKET_REPO_TOKENS` 없이 기존 `BITBUCKET_API_TOKEN`만 설정 → 정상 동작 확인
- [ ] `BITBUCKET_REPO_TOKENS='{"repo-a":"token-a"}'` 설정 → repo-a에 repo-specific token 사용 확인
- [ ] 잘못된 JSON 설정 → 앱 기동 실패 확인 (Joi validation)
- [ ] `pnpm build && pnpm lint && pnpm test` 통과