### PR TITLE
feat: per-repository webhook secrets

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -4,6 +4,17 @@
 
 ## 진행 중/최근 작업
 
+### Task 14: Per-Repository Webhook Secret 지원
+- **상태**: ✅ 완료
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| configuration.ts 수정 | ✅ | `BITBUCKET_REPO_WEBHOOK_SECRETS` → `bitbucket.repoWebhookSecrets` |
+| validation.ts 수정 | ✅ | Joi 스키마 + JSON 형식 검증 |
+| webhook.guard.ts 수정 | ✅ | `repoWebhookSecrets[slug]` → `webhookSecret` fallback |
+| 테스트 추가 | ✅ | per-repo secret 5케이스 추가 (87 tests total) |
+| 빌드/린트/테스트 통과 | ✅ | 전부 통과 |
+
 ### Task 13: Per-Repository Bitbucket Token 지원
 - **상태**: ✅ 완료
 

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,7 +1,8 @@
-import { parseRepoTokens } from "./configuration";
+import { parseJsonRecord } from "./configuration";
 
-describe("parseRepoTokens", () => {
+describe("parseJsonRecord", () => {
   let warnSpy: jest.SpyInstance;
+  const ENV_NAME = "TEST_JSON_VAR";
 
   beforeEach(() => {
     warnSpy = jest.spyOn(console, "warn").mockImplementation();
@@ -12,37 +13,37 @@ describe("parseRepoTokens", () => {
   });
 
   it("returns empty object for undefined", () => {
-    expect(parseRepoTokens(undefined)).toEqual({});
+    expect(parseJsonRecord(undefined, ENV_NAME)).toEqual({});
   });
 
   it("returns empty object for empty string", () => {
-    expect(parseRepoTokens("")).toEqual({});
+    expect(parseJsonRecord("", ENV_NAME)).toEqual({});
   });
 
   it("parses valid JSON object", () => {
     const input = '{"repo-a":"token-a","repo-b":"token-b"}';
-    expect(parseRepoTokens(input)).toEqual({
+    expect(parseJsonRecord(input, ENV_NAME)).toEqual({
       "repo-a": "token-a",
       "repo-b": "token-b",
     });
   });
 
   it("warns and returns empty object for invalid JSON", () => {
-    expect(parseRepoTokens("{invalid}")).toEqual({});
+    expect(parseJsonRecord("{invalid}", ENV_NAME)).toEqual({});
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to parse BITBUCKET_REPO_TOKENS"),
+      expect.stringContaining(`Failed to parse ${ENV_NAME}`),
     );
   });
 
   it("warns and returns empty object for JSON array", () => {
-    expect(parseRepoTokens('["a","b"]')).toEqual({});
+    expect(parseJsonRecord('["a","b"]', ENV_NAME)).toEqual({});
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("not a JSON object"),
     );
   });
 
   it("warns and returns empty object for JSON primitive", () => {
-    expect(parseRepoTokens('"just-a-string"')).toEqual({});
+    expect(parseJsonRecord('"just-a-string"', ENV_NAME)).toEqual({});
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("not a JSON object"),
     );
@@ -50,11 +51,11 @@ describe("parseRepoTokens", () => {
 
   it("skips non-string values", () => {
     const input = '{"repo-a":"token-a","repo-b":123,"repo-c":null}';
-    expect(parseRepoTokens(input)).toEqual({ "repo-a": "token-a" });
+    expect(parseJsonRecord(input, ENV_NAME)).toEqual({ "repo-a": "token-a" });
   });
 
   it("does not warn for valid input", () => {
-    parseRepoTokens('{"repo":"token"}');
+    parseJsonRecord('{"repo":"token"}', ENV_NAME);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -90,6 +90,7 @@ export default (): Record<string, unknown> => ({
     username: process.env["BITBUCKET_USERNAME"] || "",
     appPassword: process.env["BITBUCKET_APP_PASSWORD"] || "",
     webhookSecret: process.env["BITBUCKET_WEBHOOK_SECRET"] || "",
+    repoWebhookSecrets: parseRepoTokens(process.env["BITBUCKET_REPO_WEBHOOK_SECRETS"]),
   },
   workspace: {
     basePath: process.env["WORKSPACE_BASE_PATH"] || DEFAULTS.WORKSPACE_BASE_PATH,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -23,14 +23,14 @@ export const DEFAULTS = {
   LOG_LEVEL: "info",
 } as const;
 
-/** Parse BITBUCKET_REPO_TOKENS JSON into a Record<string, string> */
-export function parseRepoTokens(raw: string | undefined): Record<string, string> {
+/** Parse a JSON env var into a Record<string, string>, logging warnings on failure */
+export function parseJsonRecord(raw: string | undefined, envName: string): Record<string, string> {
   if (!raw) return {};
   try {
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       console.warn(
-        "[config] BITBUCKET_REPO_TOKENS is not a JSON object. Falling back to empty map.",
+        `[config] ${envName} is not a JSON object. Falling back to empty map.`,
       );
       return {};
     }
@@ -43,7 +43,7 @@ export function parseRepoTokens(raw: string | undefined): Record<string, string>
     return result;
   } catch (error) {
     console.warn(
-      `[config] Failed to parse BITBUCKET_REPO_TOKENS: ${(error as Error).message}. Falling back to empty map.`,
+      `[config] Failed to parse ${envName}: ${(error as Error).message}. Falling back to empty map.`,
     );
     return {};
   }
@@ -86,11 +86,11 @@ export default (): Record<string, unknown> => ({
   bitbucket: {
     baseUrl: process.env["BITBUCKET_BASE_URL"] || DEFAULTS.BITBUCKET_BASE_URL,
     apiToken: process.env["BITBUCKET_API_TOKEN"] || "",
-    repoTokens: parseRepoTokens(process.env["BITBUCKET_REPO_TOKENS"]),
+    repoTokens: parseJsonRecord(process.env["BITBUCKET_REPO_TOKENS"], "BITBUCKET_REPO_TOKENS"),
     username: process.env["BITBUCKET_USERNAME"] || "",
     appPassword: process.env["BITBUCKET_APP_PASSWORD"] || "",
     webhookSecret: process.env["BITBUCKET_WEBHOOK_SECRET"] || "",
-    repoWebhookSecrets: parseRepoTokens(process.env["BITBUCKET_REPO_WEBHOOK_SECRETS"]),
+    repoWebhookSecrets: parseJsonRecord(process.env["BITBUCKET_REPO_WEBHOOK_SECRETS"], "BITBUCKET_REPO_WEBHOOK_SECRETS"),
   },
   workspace: {
     basePath: process.env["WORKSPACE_BASE_PATH"] || DEFAULTS.WORKSPACE_BASE_PATH,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -47,6 +47,21 @@ export const validationSchema = Joi.object({
   BITBUCKET_USERNAME: Joi.string().allow("").default(""),
   BITBUCKET_APP_PASSWORD: Joi.string().allow("").default(""),
   BITBUCKET_WEBHOOK_SECRET: Joi.string().allow("").default(""),
+  BITBUCKET_REPO_WEBHOOK_SECRETS: Joi.string()
+    .allow("")
+    .default("")
+    .custom((value: string) => {
+      if (!value) return value;
+      try {
+        const parsed: unknown = JSON.parse(value);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new Error("must be a JSON object");
+        }
+        return value;
+      } catch (e) {
+        throw new Error(`Invalid BITBUCKET_REPO_WEBHOOK_SECRETS: ${(e as Error).message}`);
+      }
+    }),
   WORKSPACE_BASE_PATH: Joi.string().default(DEFAULTS.WORKSPACE_BASE_PATH),
   WORKSPACE_MAX_CONCURRENT: Joi.number().default(DEFAULTS.WORKSPACE_MAX_CONCURRENT),
   REVIEW_TRIGGER_MODE: Joi.string()

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -2,6 +2,21 @@ import * as Joi from "joi";
 import { dbPoolValidationSchema } from "@lib/database";
 import { DEFAULTS } from "./configuration";
 
+function jsonObjectValidator(label: string) {
+  return (value: string) => {
+    if (!value) return value;
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error("must be a JSON object");
+      }
+      return value;
+    } catch (e) {
+      throw new Error(`Invalid ${label}: ${(e as Error).message}`);
+    }
+  };
+}
+
 export const validationSchema = Joi.object({
   NODE_ENV: Joi.string()
     .valid("development", "production", "test", "staging", "local")
@@ -32,36 +47,14 @@ export const validationSchema = Joi.object({
   BITBUCKET_REPO_TOKENS: Joi.string()
     .allow("")
     .default("")
-    .custom((value: string) => {
-      if (!value) return value;
-      try {
-        const parsed: unknown = JSON.parse(value);
-        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-          throw new Error("must be a JSON object");
-        }
-        return value;
-      } catch (e) {
-        throw new Error(`Invalid BITBUCKET_REPO_TOKENS: ${(e as Error).message}`);
-      }
-    }),
+    .custom(jsonObjectValidator("BITBUCKET_REPO_TOKENS")),
   BITBUCKET_USERNAME: Joi.string().allow("").default(""),
   BITBUCKET_APP_PASSWORD: Joi.string().allow("").default(""),
   BITBUCKET_WEBHOOK_SECRET: Joi.string().allow("").default(""),
   BITBUCKET_REPO_WEBHOOK_SECRETS: Joi.string()
     .allow("")
     .default("")
-    .custom((value: string) => {
-      if (!value) return value;
-      try {
-        const parsed: unknown = JSON.parse(value);
-        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-          throw new Error("must be a JSON object");
-        }
-        return value;
-      } catch (e) {
-        throw new Error(`Invalid BITBUCKET_REPO_WEBHOOK_SECRETS: ${(e as Error).message}`);
-      }
-    }),
+    .custom(jsonObjectValidator("BITBUCKET_REPO_WEBHOOK_SECRETS")),
   WORKSPACE_BASE_PATH: Joi.string().default(DEFAULTS.WORKSPACE_BASE_PATH),
   WORKSPACE_MAX_CONCURRENT: Joi.number().default(DEFAULTS.WORKSPACE_MAX_CONCURRENT),
   REVIEW_TRIGGER_MODE: Joi.string()

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpStatus,
   UseGuards,
   BadRequestException,
+  Req,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectQueue } from "@nestjs/bullmq";
@@ -44,7 +45,21 @@ export class WebhookController {
   async handleBitbucketWebhook(
     @Body() body: IBitbucketWebhookBase,
     @Headers("x-event-key") eventKey: string,
+    @Req() request: { verifiedRepoSlug?: string },
   ): Promise<{ accepted: boolean; reason?: string }> {
+    // Enforce that the repo slug used for HMAC verification matches the payload
+    const payloadSlug = body.repository?.slug;
+    if (
+      request.verifiedRepoSlug &&
+      payloadSlug &&
+      request.verifiedRepoSlug !== payloadSlug
+    ) {
+      this.logger.warn(
+        `Repo slug mismatch: verified="${request.verifiedRepoSlug}" vs payload="${payloadSlug}"`,
+      );
+      throw new BadRequestException("Repository identity mismatch");
+    }
+
     const triggerMode = this.configService.get<string>(
       "trigger.mode",
       "mention",

--- a/src/webhook/webhook.guard.spec.ts
+++ b/src/webhook/webhook.guard.spec.ts
@@ -16,10 +16,12 @@ jest.mock("@lib/logger", () => ({
 function buildExecutionContext(overrides: {
   headers?: Record<string, string>;
   rawBody?: Buffer;
+  body?: Record<string, unknown>;
 }): ExecutionContext {
   const request = {
     headers: overrides.headers ?? {},
     rawBody: overrides.rawBody,
+    body: overrides.body,
   };
   return {
     switchToHttp: () => ({
@@ -28,110 +30,203 @@ function buildExecutionContext(overrides: {
   } as unknown as ExecutionContext;
 }
 
+/** Helper: build a config mock that responds to per-repo secret keys */
+function buildConfigMock(overrides: {
+  repoWebhookSecrets?: Record<string, string>;
+  webhookSecret?: string;
+}): ConfigService {
+  const defaults: Record<string, unknown> = {
+    "bitbucket.repoWebhookSecrets": overrides.repoWebhookSecrets ?? {},
+    "bitbucket.webhookSecret": overrides.webhookSecret ?? "",
+  };
+  return {
+    get: jest.fn((key: string, defaultValue?: unknown) =>
+      key in defaults ? defaults[key] : defaultValue,
+    ),
+  } as unknown as ConfigService;
+}
+
 describe("WebhookGuard", () => {
   const SECRET = "test-webhook-secret";
-  let guard: WebhookGuard;
-  let configService: ConfigService;
 
-  beforeEach(() => {
-    configService = {
-      get: jest.fn(),
-    } as unknown as ConfigService;
-    guard = new WebhookGuard(configService);
-  });
+  describe("global secret (backward compat)", () => {
+    let guard: WebhookGuard;
 
-  it("should return false when secret is NOT configured (fail-closed)", () => {
-    (configService.get as jest.Mock).mockReturnValue(undefined);
-
-    const ctx = buildExecutionContext({
-      headers: { "x-hub-signature": "some-sig" },
-      rawBody: Buffer.from("body"),
+    beforeEach(() => {
+      guard = new WebhookGuard(buildConfigMock({ webhookSecret: SECRET }));
     });
 
-    expect(guard.canActivate(ctx)).toBe(false);
-  });
-
-  it("should return false when x-hub-signature header is missing", () => {
-    (configService.get as jest.Mock).mockReturnValue(SECRET);
-
-    const ctx = buildExecutionContext({
-      headers: {},
-      rawBody: Buffer.from("body"),
+    it("should return false when x-hub-signature header is missing", () => {
+      const ctx = buildExecutionContext({
+        headers: {},
+        rawBody: Buffer.from("body"),
+      });
+      expect(guard.canActivate(ctx)).toBe(false);
     });
 
-    expect(guard.canActivate(ctx)).toBe(false);
-  });
-
-  it("should return false when rawBody is not available", () => {
-    (configService.get as jest.Mock).mockReturnValue(SECRET);
-
-    const ctx = buildExecutionContext({
-      headers: { "x-hub-signature": "some-sig" },
-      rawBody: undefined,
+    it("should return false when rawBody is not available", () => {
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": "some-sig" },
+        rawBody: undefined,
+      });
+      expect(guard.canActivate(ctx)).toBe(false);
     });
 
-    expect(guard.canActivate(ctx)).toBe(false);
-  });
+    it("should return true when signature matches (with sha256= prefix)", () => {
+      const body = '{"action":"pr:comment:added"}';
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", SECRET).update(rawBody).digest("hex");
 
-  it("should return true when signature matches (with sha256= prefix)", () => {
-    (configService.get as jest.Mock).mockReturnValue(SECRET);
-
-    const body = '{"action":"pr:comment:added"}';
-    const rawBody = Buffer.from(body, "utf8");
-    const hex = createHmac("sha256", SECRET).update(rawBody).digest("hex");
-
-    const ctx = buildExecutionContext({
-      headers: { "x-hub-signature": `sha256=${hex}` },
-      rawBody,
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${hex}` },
+        rawBody,
+      });
+      expect(guard.canActivate(ctx)).toBe(true);
     });
 
-    expect(guard.canActivate(ctx)).toBe(true);
-  });
+    it("should return true when signature matches (without prefix)", () => {
+      const body = '{"action":"pr:comment:added"}';
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", SECRET).update(rawBody).digest("hex");
 
-  it("should return true when signature matches (without prefix)", () => {
-    (configService.get as jest.Mock).mockReturnValue(SECRET);
-
-    const body = '{"action":"pr:comment:added"}';
-    const rawBody = Buffer.from(body, "utf8");
-    const hex = createHmac("sha256", SECRET).update(rawBody).digest("hex");
-
-    const ctx = buildExecutionContext({
-      headers: { "x-hub-signature": hex },
-      rawBody,
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": hex },
+        rawBody,
+      });
+      expect(guard.canActivate(ctx)).toBe(true);
     });
 
-    expect(guard.canActivate(ctx)).toBe(true);
-  });
+    it("should return false when signature does NOT match", () => {
+      const rawBody = Buffer.from("real-body", "utf8");
+      const wrongSig = createHmac("sha256", SECRET)
+        .update("different-body")
+        .digest("hex");
 
-  it("should return false when signature does NOT match", () => {
-    (configService.get as jest.Mock).mockReturnValue(SECRET);
-
-    const rawBody = Buffer.from("real-body", "utf8");
-    const wrongSig = createHmac("sha256", SECRET)
-      .update("different-body")
-      .digest("hex");
-
-    const ctx = buildExecutionContext({
-      headers: { "x-hub-signature": `sha256=${wrongSig}` },
-      rawBody,
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${wrongSig}` },
+        rawBody,
+      });
+      expect(guard.canActivate(ctx)).toBe(false);
     });
 
-    expect(guard.canActivate(ctx)).toBe(false);
+    it("should return false when timingSafeEqual throws (length mismatch)", () => {
+      const rawBody = Buffer.from("body", "utf8");
+      const shortSig = "abc";
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": shortSig },
+        rawBody,
+      });
+      expect(guard.canActivate(ctx)).toBe(false);
+    });
   });
 
-  it("should return false when timingSafeEqual throws (length mismatch)", () => {
-    (configService.get as jest.Mock).mockReturnValue(SECRET);
+  describe("no secret configured (fail-closed)", () => {
+    it("should return false when no global or repo secret", () => {
+      const guard = new WebhookGuard(buildConfigMock({}));
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": "some-sig" },
+        rawBody: Buffer.from("body"),
+        body: { repository: { slug: "unknown-repo" } },
+      });
+      expect(guard.canActivate(ctx)).toBe(false);
+    });
+  });
 
-    const rawBody = Buffer.from("body", "utf8");
-    // A signature with different length than expected hex digest will cause
-    // timingSafeEqual to throw because Buffer lengths differ
-    const shortSig = "abc";
+  describe("per-repo webhook secrets", () => {
+    const REPO_A_SECRET = "secret-for-repo-a";
+    const REPO_B_SECRET = "secret-for-repo-b";
+    let guard: WebhookGuard;
 
-    const ctx = buildExecutionContext({
-      headers: { "x-hub-signature": shortSig },
-      rawBody,
+    beforeEach(() => {
+      guard = new WebhookGuard(
+        buildConfigMock({
+          repoWebhookSecrets: {
+            "repo-a": REPO_A_SECRET,
+            "repo-b": REPO_B_SECRET,
+          },
+        }),
+      );
     });
 
-    expect(guard.canActivate(ctx)).toBe(false);
+    it("should use repo-specific secret for repo-a", () => {
+      const body = JSON.stringify({ repository: { slug: "repo-a" } });
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", REPO_A_SECRET)
+        .update(rawBody)
+        .digest("hex");
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${hex}` },
+        rawBody,
+        body: { repository: { slug: "repo-a" } },
+      });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it("should use repo-specific secret for repo-b", () => {
+      const body = JSON.stringify({ repository: { slug: "repo-b" } });
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", REPO_B_SECRET)
+        .update(rawBody)
+        .digest("hex");
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${hex}` },
+        rawBody,
+        body: { repository: { slug: "repo-b" } },
+      });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it("should reject when signed with wrong repo secret", () => {
+      const body = JSON.stringify({ repository: { slug: "repo-a" } });
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", REPO_B_SECRET)
+        .update(rawBody)
+        .digest("hex");
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${hex}` },
+        rawBody,
+        body: { repository: { slug: "repo-a" } },
+      });
+      expect(guard.canActivate(ctx)).toBe(false);
+    });
+
+    it("should fall back to global secret when repo not in map", () => {
+      const globalSecret = "global-fallback";
+      const guardWithFallback = new WebhookGuard(
+        buildConfigMock({
+          repoWebhookSecrets: { "repo-a": REPO_A_SECRET },
+          webhookSecret: globalSecret,
+        }),
+      );
+
+      const body = JSON.stringify({ repository: { slug: "repo-c" } });
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", globalSecret)
+        .update(rawBody)
+        .digest("hex");
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${hex}` },
+        rawBody,
+        body: { repository: { slug: "repo-c" } },
+      });
+      expect(guardWithFallback.canActivate(ctx)).toBe(true);
+    });
+
+    it("should reject unknown repo when no global fallback", () => {
+      const body = JSON.stringify({ repository: { slug: "unknown" } });
+      const rawBody = Buffer.from(body, "utf8");
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": "sha256=abc" },
+        rawBody,
+        body: { repository: { slug: "unknown" } },
+      });
+      expect(guard.canActivate(ctx)).toBe(false);
+    });
   });
 });

--- a/src/webhook/webhook.guard.spec.ts
+++ b/src/webhook/webhook.guard.spec.ts
@@ -119,6 +119,19 @@ describe("WebhookGuard", () => {
       });
       expect(guard.canActivate(ctx)).toBe(false);
     });
+
+    it("should use global secret when body has no repository slug", () => {
+      const body = '{"action":"test"}';
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", SECRET).update(rawBody).digest("hex");
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${hex}` },
+        rawBody,
+        body: { action: "test" },
+      });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
   });
 
   describe("no secret configured (fail-closed)", () => {

--- a/src/webhook/webhook.guard.ts
+++ b/src/webhook/webhook.guard.ts
@@ -23,7 +23,10 @@ export class WebhookGuard implements CanActivate {
       "bitbucket.webhookSecret",
       "",
     );
-    const secret = (repoSlug && repoSecrets[repoSlug]) || globalSecret;
+    const secret =
+      (repoSlug && Object.hasOwn(repoSecrets, repoSlug)
+        ? repoSecrets[repoSlug]
+        : undefined) || globalSecret;
 
     if (!secret) {
       this.logger.error(
@@ -53,10 +56,15 @@ export class WebhookGuard implements CanActivate {
       .digest("hex");
 
     try {
-      return timingSafeEqual(
+      const valid = timingSafeEqual(
         Buffer.from(signature, "utf8"),
         Buffer.from(expectedSignature, "utf8"),
       );
+      if (valid && repoSlug) {
+        // Store verified slug so controller can enforce identity consistency
+        request.verifiedRepoSlug = repoSlug;
+      }
+      return valid;
     } catch {
       this.logger.warn("Webhook signature verification failed");
       return false;

--- a/src/webhook/webhook.guard.ts
+++ b/src/webhook/webhook.guard.ts
@@ -10,15 +10,27 @@ export class WebhookGuard implements CanActivate {
   constructor(private readonly configService: ConfigService) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const secret = this.configService.get<string>("bitbucket.webhookSecret");
+    const request = context.switchToHttp().getRequest();
+
+    // Extract repo slug from parsed body for per-repo secret lookup
+    const repoSlug: string | undefined = request.body?.repository?.slug;
+
+    const repoSecrets =
+      this.configService.get<Record<string, string>>(
+        "bitbucket.repoWebhookSecrets",
+      ) ?? {};
+    const globalSecret = this.configService.get<string>(
+      "bitbucket.webhookSecret",
+      "",
+    );
+    const secret = (repoSlug && repoSecrets[repoSlug]) || globalSecret;
+
     if (!secret) {
       this.logger.error(
-        "Webhook secret not configured — rejecting request (fail-closed)",
+        `No webhook secret for repo "${repoSlug ?? "unknown"}" — rejecting request (fail-closed)`,
       );
       return false;
     }
-
-    const request = context.switchToHttp().getRequest();
     const rawSignature = request.headers["x-hub-signature"] as string | undefined;
     if (!rawSignature) {
       this.logger.warn("Missing x-hub-signature header");


### PR DESCRIPTION
## Summary

- `BITBUCKET_REPO_WEBHOOK_SECRETS` 환경변수 추가 (JSON: repo slug → secret)
- `WebhookGuard`가 `request.body.repository.slug`에서 repo 식별 후 per-repo secret으로 HMAC 검증
- Lookup 순서: `repoWebhookSecrets[slug]` → `webhookSecret` (전역 fallback)
- 기존 단일 `BITBUCKET_WEBHOOK_SECRET`만 사용해도 하위 호환

**긴급**: EKS에서 `BITBUCKET_WEBHOOK_SECRET`이 비워진 상태로 모든 webhook이 거부 중. 이 변경이 배포되면 per-repo secret으로 정상 동작 복구.

## Test plan

- [ ] `pnpm build && pnpm lint && pnpm test` 통과 (87 tests)
- [ ] 이미지 빌드 → EKS 배포
- [ ] lxp_services PR webhook 정상 동작 확인
- [ ] tdea_services_ai PR #30 webhook 정상 동작 확인