### PR TITLE
fix: use repository.name instead of slug for Bitbucket Cloud

### DIFF
--- a/src/webhook/interfaces/webhook.interfaces.ts
+++ b/src/webhook/interfaces/webhook.interfaces.ts
@@ -28,7 +28,7 @@ export interface IBitbucketWebhookBase {
     };
   };
   readonly repository: {
-    readonly slug?: string;
+    readonly name?: string;
     readonly full_name: string;
     readonly links: {
       readonly clone?: ReadonlyArray<{

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -48,7 +48,9 @@ export class WebhookController {
     @Req() request: { verifiedRepoSlug?: string },
   ): Promise<{ accepted: boolean; reason?: string }> {
     // Enforce that the repo slug used for HMAC verification matches the payload
-    const payloadSlug = body.repository?.slug;
+    const payloadSlug =
+      body.repository?.name ??
+      body.repository?.full_name?.split("/")[1];
     if (
       request.verifiedRepoSlug &&
       payloadSlug &&
@@ -259,7 +261,7 @@ export class WebhookController {
       `https://bitbucket.org/${body.repository.full_name}.git`;
 
     const repositorySlug =
-      body.repository.slug ||
+      body.repository.name ||
       body.repository.full_name.split("/").pop() ||
       "";
 

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -49,8 +49,8 @@ export class WebhookController {
   ): Promise<{ accepted: boolean; reason?: string }> {
     // Enforce that the repo slug used for HMAC verification matches the payload
     const payloadSlug =
-      body.repository?.name ??
-      body.repository?.full_name?.split("/")[1];
+      body.repository?.full_name?.split("/")[1] ??
+      body.repository?.name;
     if (
       request.verifiedRepoSlug &&
       payloadSlug &&
@@ -261,8 +261,8 @@ export class WebhookController {
       `https://bitbucket.org/${body.repository.full_name}.git`;
 
     const repositorySlug =
-      body.repository.name ||
       body.repository.full_name.split("/").pop() ||
+      body.repository.name ||
       "";
 
     return {

--- a/src/webhook/webhook.guard.spec.ts
+++ b/src/webhook/webhook.guard.spec.ts
@@ -140,7 +140,7 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": "some-sig" },
         rawBody: Buffer.from("body"),
-        body: { repository: { slug: "unknown-repo" } },
+        body: { repository: { name:"unknown-repo" } },
       });
       expect(guard.canActivate(ctx)).toBe(false);
     });
@@ -163,7 +163,7 @@ describe("WebhookGuard", () => {
     });
 
     it("should use repo-specific secret for repo-a", () => {
-      const body = JSON.stringify({ repository: { slug: "repo-a" } });
+      const body = JSON.stringify({ repository: { name:"repo-a" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", REPO_A_SECRET)
         .update(rawBody)
@@ -172,13 +172,13 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { slug: "repo-a" } },
+        body: { repository: { name:"repo-a" } },
       });
       expect(guard.canActivate(ctx)).toBe(true);
     });
 
     it("should use repo-specific secret for repo-b", () => {
-      const body = JSON.stringify({ repository: { slug: "repo-b" } });
+      const body = JSON.stringify({ repository: { name:"repo-b" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", REPO_B_SECRET)
         .update(rawBody)
@@ -187,13 +187,13 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { slug: "repo-b" } },
+        body: { repository: { name:"repo-b" } },
       });
       expect(guard.canActivate(ctx)).toBe(true);
     });
 
     it("should reject when signed with wrong repo secret", () => {
-      const body = JSON.stringify({ repository: { slug: "repo-a" } });
+      const body = JSON.stringify({ repository: { name:"repo-a" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", REPO_B_SECRET)
         .update(rawBody)
@@ -202,7 +202,7 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { slug: "repo-a" } },
+        body: { repository: { name:"repo-a" } },
       });
       expect(guard.canActivate(ctx)).toBe(false);
     });
@@ -216,7 +216,7 @@ describe("WebhookGuard", () => {
         }),
       );
 
-      const body = JSON.stringify({ repository: { slug: "repo-c" } });
+      const body = JSON.stringify({ repository: { name:"repo-c" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", globalSecret)
         .update(rawBody)
@@ -225,19 +225,19 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { slug: "repo-c" } },
+        body: { repository: { name:"repo-c" } },
       });
       expect(guardWithFallback.canActivate(ctx)).toBe(true);
     });
 
     it("should reject unknown repo when no global fallback", () => {
-      const body = JSON.stringify({ repository: { slug: "unknown" } });
+      const body = JSON.stringify({ repository: { name:"unknown" } });
       const rawBody = Buffer.from(body, "utf8");
 
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": "sha256=abc" },
         rawBody,
-        body: { repository: { slug: "unknown" } },
+        body: { repository: { name:"unknown" } },
       });
       expect(guard.canActivate(ctx)).toBe(false);
     });

--- a/src/webhook/webhook.guard.spec.ts
+++ b/src/webhook/webhook.guard.spec.ts
@@ -140,7 +140,7 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": "some-sig" },
         rawBody: Buffer.from("body"),
-        body: { repository: { name:"unknown-repo" } },
+        body: { repository: { full_name: "ws/unknown-repo" } },
       });
       expect(guard.canActivate(ctx)).toBe(false);
     });
@@ -163,7 +163,7 @@ describe("WebhookGuard", () => {
     });
 
     it("should use repo-specific secret for repo-a", () => {
-      const body = JSON.stringify({ repository: { name:"repo-a" } });
+      const body = JSON.stringify({ repository: { full_name: "ws/repo-a" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", REPO_A_SECRET)
         .update(rawBody)
@@ -172,13 +172,13 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { name:"repo-a" } },
+        body: { repository: { full_name: "ws/repo-a" } },
       });
       expect(guard.canActivate(ctx)).toBe(true);
     });
 
     it("should use repo-specific secret for repo-b", () => {
-      const body = JSON.stringify({ repository: { name:"repo-b" } });
+      const body = JSON.stringify({ repository: { full_name: "ws/repo-b" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", REPO_B_SECRET)
         .update(rawBody)
@@ -187,13 +187,13 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { name:"repo-b" } },
+        body: { repository: { full_name: "ws/repo-b" } },
       });
       expect(guard.canActivate(ctx)).toBe(true);
     });
 
     it("should reject when signed with wrong repo secret", () => {
-      const body = JSON.stringify({ repository: { name:"repo-a" } });
+      const body = JSON.stringify({ repository: { full_name: "ws/repo-a" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", REPO_B_SECRET)
         .update(rawBody)
@@ -202,7 +202,7 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { name:"repo-a" } },
+        body: { repository: { full_name: "ws/repo-a" } },
       });
       expect(guard.canActivate(ctx)).toBe(false);
     });
@@ -216,7 +216,7 @@ describe("WebhookGuard", () => {
         }),
       );
 
-      const body = JSON.stringify({ repository: { name:"repo-c" } });
+      const body = JSON.stringify({ repository: { full_name: "ws/repo-c" } });
       const rawBody = Buffer.from(body, "utf8");
       const hex = createHmac("sha256", globalSecret)
         .update(rawBody)
@@ -225,21 +225,36 @@ describe("WebhookGuard", () => {
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": `sha256=${hex}` },
         rawBody,
-        body: { repository: { name:"repo-c" } },
+        body: { repository: { full_name: "ws/repo-c" } },
       });
       expect(guardWithFallback.canActivate(ctx)).toBe(true);
     });
 
     it("should reject unknown repo when no global fallback", () => {
-      const body = JSON.stringify({ repository: { name:"unknown" } });
+      const body = JSON.stringify({ repository: { full_name: "ws/unknown" } });
       const rawBody = Buffer.from(body, "utf8");
 
       const ctx = buildExecutionContext({
         headers: { "x-hub-signature": "sha256=abc" },
         rawBody,
-        body: { repository: { name:"unknown" } },
+        body: { repository: { full_name: "ws/unknown" } },
       });
       expect(guard.canActivate(ctx)).toBe(false);
+    });
+
+    it("should fall back to repository.name when full_name is absent", () => {
+      const body = JSON.stringify({ repository: { name: "repo-a" } });
+      const rawBody = Buffer.from(body, "utf8");
+      const hex = createHmac("sha256", REPO_A_SECRET)
+        .update(rawBody)
+        .digest("hex");
+
+      const ctx = buildExecutionContext({
+        headers: { "x-hub-signature": `sha256=${hex}` },
+        rawBody,
+        body: { repository: { name: "repo-a" } },
+      });
+      expect(guard.canActivate(ctx)).toBe(true);
     });
   });
 });

--- a/src/webhook/webhook.guard.ts
+++ b/src/webhook/webhook.guard.ts
@@ -12,12 +12,12 @@ export class WebhookGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
 
-    // Extract repo slug from parsed body for per-repo secret lookup
-    // Bitbucket Cloud uses "name" (not "slug") in the repository object;
-    // fall back to the second segment of full_name if name is absent.
+    // Extract repo slug from parsed body for per-repo secret lookup.
+    // Bitbucket Cloud's URL slug lives in full_name ("workspace/slug");
+    // repository.name is a display name that can diverge after renames.
     const repoSlug: string | undefined =
-      request.body?.repository?.name ??
-      request.body?.repository?.full_name?.split("/")[1];
+      request.body?.repository?.full_name?.split("/")[1] ??
+      request.body?.repository?.name;
 
     const repoSecrets =
       this.configService.get<Record<string, string>>(

--- a/src/webhook/webhook.guard.ts
+++ b/src/webhook/webhook.guard.ts
@@ -13,7 +13,11 @@ export class WebhookGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
 
     // Extract repo slug from parsed body for per-repo secret lookup
-    const repoSlug: string | undefined = request.body?.repository?.slug;
+    // Bitbucket Cloud uses "name" (not "slug") in the repository object;
+    // fall back to the second segment of full_name if name is absent.
+    const repoSlug: string | undefined =
+      request.body?.repository?.name ??
+      request.body?.repository?.full_name?.split("/")[1];
 
     const repoSecrets =
       this.configService.get<Record<string, string>>(


### PR DESCRIPTION
## Summary
- Bitbucket Cloud의 repository 객체에는 `slug` 필드가 존재하지 않음 — 실제 필드는 `name`
- `repository.slug` 참조 → `repository.name` (fallback: `full_name.split("/")[1]`)으로 변경
- Guard, Controller, Interface, 테스트 모두 일괄 수정

## Root Cause
per-repo webhook secret lookup이 `repository.slug`(undefined)로 조회 → 매칭 실패 → global secret도 비어있어 fail-closed → 403

## Test plan
- [x] `pnpm build` 성공
- [x] `pnpm test` 88개 전체 통과
- [ ] 이미지 빌드 후 EKS 배포하여 실제 webhook 수신 확인