### PR TITLE
fix: sanitize Codex error output to prevent prompt leakage

### DIFF
--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -100,8 +100,15 @@ export class CodexService {
         `Codex review failed after ${durationMs}ms: ${error.message}`,
       );
 
+      // error.message from execFile includes the full command (with prompt)
+      // which should not leak into PR comments. Extract just the cause.
+      const cause = error.stderr
+        || error.message.replace(/^Command failed:.*?\n/, "").trim()
+        || "Unknown error";
+      const sanitizedOutput = `Codex run failed (exit ${error.code || 1}): ${cause}`;
+
       return {
-        rawOutput: error.stdout || error.message,
+        rawOutput: error.stdout || sanitizedOutput,
         exitCode: error.code || 1,
         durationMs,
       };

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -101,11 +101,12 @@ export class CodexService {
       );
 
       // error.message from execFile includes the full command (with prompt)
-      // which should not leak into PR comments. Extract just the cause.
-      const cause = error.stderr
-        || error.message.replace(/^Command failed:.*?\n/, "").trim()
-        || "Unknown error";
-      const sanitizedOutput = `Codex run failed (exit ${error.code || 1}): ${cause}`;
+      // which must not leak into PR comments. Only trust stderr for details;
+      // never parse error.message as it can contain multi-line prompt text.
+      const exitCode = error.code || 1;
+      const sanitizedOutput = error.stderr
+        ? `Codex run failed (exit ${exitCode}): ${error.stderr.trim()}`
+        : `Codex run failed (exit ${exitCode}). Check worker logs for details.`;
 
       return {
         rawOutput: error.stdout || sanitizedOutput,


### PR DESCRIPTION
## Summary
- Codex CLI 실행 실패 시 `error.message`에 전체 명령어(프롬프트 포함)가 포함되어 PR 코멘트에 시스템 프롬프트가 노출되는 문제 수정
- `stderr` 또는 `error.message`에서 `Command failed:` prefix 제거한 에러 원인만 `rawOutput`에 포함
- 전체 에러는 worker 로그에만 기록

## Test plan
- [x] `pnpm build` 성공
- [x] `pnpm test` 89개 전체 통과