### PR TITLE
fix: use tini as PID 1 to reap codex-linux-sandbox zombies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 RUN corepack enable
-RUN apk add --no-cache git ca-certificates curl
+# tini: PID 1 init that reaps orphaned grandchildren (codex-linux-sandbox)
+# spawned by the codex CLI. Without it Node leaks zombies until cgroup
+# pids.max is hit and new threads fail to spawn (EAGAIN).
+RUN apk add --no-cache git ca-certificates curl tini
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --prod --frozen-lockfile
@@ -37,4 +40,5 @@ COPY --from=build /app/dist ./dist
 EXPOSE 3000
 EXPOSE 9463
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["node", "dist/main"]


### PR DESCRIPTION
## Summary

`codex-code-review` 운영 pod가 2026-05-11 08:07 UTC부터 모든 PR 리뷰를 정확히 5분 후 `Codex output file could not be read` 로 실패시키는 인시던트가 발생했다. 원인은 cgroup `pids.max` 도달이었다. Dockerfile에 `tini` 를 PID 1로 추가해 codex가 fork하는 sandbox helper 손자가 좀비로 누적되지 않도록 한다.

## What / Why / How

### 무엇이 잘못됐나
- 운영 pod (`lxp-tools/codex-code-review`, uptime 16d) 내부 상태:
  ```
  pids.current = 9282 / 9297     ← cgroup 한도 99.84% 사용
  processes    = 9
  threads      = 9274
  zombies      = 8952 × [codex-linux-sandbox], State Z, PPid 1
  ```
- 슬롯이 거의 다 차자 codex CLI가 worker thread 생성 단계에서 panic:
  ```
  OS can't spawn worker thread: Resource temporarily unavailable (os error 11)
  creating threadpool failed: IOError(Os { code: 11, kind: WouldBlock })
  ```
- 호출자(`CodexService.spawnCodex`) 입장에서는 자식이 응답 없이 5분 wall-clock 타임아웃에 걸리고, `--output-last-message` 파일은 비어 있어 `readFile` 이 실패 → "Codex output file could not be read".

### 왜 좀비가 쌓였나
- 현재 Dockerfile은 `CMD ["node", "dist/main"]` 만 두어 Node가 직접 PID 1.
- Node의 자동 reaping은 `child_process.spawn`으로 만든 **직속 자식만** 대상. codex CLI가 fork하는 `codex-linux-sandbox` 는 Node 입장에서 **손자**.
- 손자가 종료해도 부모(codex CLI)가 reap하지 못한 채 codex 자체가 종료 → 손자가 orphan이 되어 PID 1으로 reparent → PID 1이 Node인데 Node는 generic init이 아니므로 `waitpid()` 호출 없음 → 좀비 누적.

### Fix
- Alpine 패키지 `tini` 를 추가하고 `ENTRYPOINT ["/sbin/tini", "--"]` 로 PID 1을 교체.
- `tini` 는 표준 init 동작(SIGCHLD 핸들러에서 `waitpid(-1, ..., WNOHANG)` 루프)을 제공해 orphan 손자를 즉시 reap.

### 검증 (로컬)
- `docker build --target runtime` 통과, `/sbin/tini --version` → 0.19.0.
- 컨테이너 내부 PID 1 = `/sbin/tini`.
- orphan 손자 시뮬레이션: 부모 sh 종료 후 손자 sleep 프로세스가 reparent되어 좀비로 남지 않음을 `ps -ef` 로 확인 (실 `Z` 상태 0).

### 배포 후 모니터링 권장
- 운영 pod에 다음을 확인:
  ```
  kubectl exec -n lxp-tools <pod> -- sh -c 'cat /sys/fs/cgroup/pids.current; ps -ef | grep -c codex-linux-san'
  ```
- 이전 패턴이라면 PR 처리 N건당 좀비 수가 누적 증가했음. fix 후엔 idle 시 0 근처를 유지해야 함.
- (선택) Grafana 알럿: `pids.current / pids.max > 0.8` 임계.

## Risk
- `ENTRYPOINT` 가 새로 도입됨. helm chart (`charts/code-review-worker/templates/deployment.yaml`) 의 main container 는 `command`/`args` override가 없어 영향 없음. migration init container 만 `command: ["npx", "typeorm", ...]` 로 override하므로 동일.

## Test plan
- [x] `docker build --target runtime` 통과
- [x] 컨테이너에서 `tini` 실행, PID 1 확인
- [x] orphan grandchild reap 동작 확인
- [ ] 머지 후 운영 이미지 배포, pod 내부 `ps -ef | grep codex-linux-san` 가 idle 시 0 유지
- [ ] 실제 PR 리뷰 1건 처리 후 zombie 증가 없음 확인