### PR TITLE
feat: add GPT-5.6 model family support

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -4,6 +4,23 @@
 
 ## 진행 중/최근 작업
 
+### Task 28: GPT-5.6 모델 패밀리 전환
+- **상태**: ✅ 완료
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 전환 설계/계획 승인 | ✅ | 기본 모델 `gpt-5.6-sol`, 런타임 버전 probe 없이 클린 전환하는 설계와 단계별 계획 확정 |
+| Codex CLI 업그레이드 | ✅ | Docker runtime을 공식 최소 `0.144.0` 이상인 `@openai/codex@0.144.1`로 고정, npm 레지스트리 버전 확인 |
+| 기본 모델 전환 | ✅ | 애플리케이션, `.env.example`, Compose, Helm, README 기본값을 `gpt-5.6-sol`로 일괄 변경 |
+| Reasoning 검증 | ✅ | `none`/`low`/`medium`/`high`/`xhigh`/`max`만 허용하고 기본값 `medium` 유지 |
+| 모델 전달 회귀 테스트 | ✅ | `gpt-5.6`, Sol, Terra, Luna가 정확한 `--model` argv와 `medium` 설정으로 전달되는 4케이스 추가 |
+| 배포 설정 검증 | ✅ | 기본/Sol/Terra/Luna Helm 렌더링, `helm lint`, `docker compose config --quiet` 성공 |
+| 독립 코드 리뷰 | ✅ | 호환성·보안 차단 finding 없음 |
+| 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (187 tests) |
+| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 85.92% |
+| 보안 체크리스트 | ✅ | 하드코딩 시크릿 없음, reasoning 입력을 Joi enum으로 검증, 신규 에러 누출 없음 |
+| Docker 이미지 검증 | ⚠️ | OrbStack Docker 소켓이 없어 이미지 빌드 및 컨테이너 내부 `codex --version` 확인은 실행하지 못함 |
+
 ### Task 27: GPT-5.6 모델 패밀리 호환성 검토
 - **상태**: ✅ 검토 완료 (현재 운영 이미지 기준 미대응)
 

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,8 +1,21 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-07-03
+> 마지막 업데이트: 2026-07-10
 
 ## 진행 중/최근 작업
+
+### Task 27: GPT-5.6 모델 패밀리 호환성 검토
+- **상태**: ✅ 검토 완료 (현재 운영 이미지 기준 미대응)
+
+| 검토 항목 | 판정 | 근거 |
+|-----------|------|------|
+| 모델 ID 전달 경로 | ✅ | `CODEX_MODEL`은 임의 문자열로 수용되어 `codex exec --model`에 그대로 전달되고, Helm에서 `gpt-5.6-sol`/`terra`/`luna` 렌더링 확인 |
+| 공식 Codex 최소 버전 | ❌ | OpenAI 공식 요구사항은 Codex CLI `0.144.0` 이상이나 Dockerfile은 `@openai/codex@0.124.0` 고정 |
+| 기본 설정/배포 예시 | ⚠️ | 애플리케이션, `.env.example`, Compose, Helm, 문서의 기본 모델은 모두 `gpt-5.5` |
+| Reasoning 호환성 | ⚠️ | 기본 `medium`은 세 변형에서 유효하지만 `CODEX_REASONING_EFFORT` 검증이 없고 CLI `0.124.0`은 GPT-5.6의 `max`를 정식 지원하지 않음 |
+| 회귀 테스트 | ⚠️ | Codex 실행/설정 테스트는 통과하지만 GPT-5.6 세 모델 ID 전달 및 최소 CLI 버전을 직접 검증하는 테스트는 없음 |
+| 집중 검증 | ✅ | 관련 Jest 27 tests 통과, Helm에서 세 모델 ID의 ConfigMap 전달 확인 |
+| 전체 DoD | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 175 tests, `pnpm test:cov --runInBand` statement 85.74% 통과 |
 
 ### Task 26: 대형 PR Codex 브랜치 리뷰 모드
 - **상태**: ✅ 완료

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -20,7 +20,7 @@
 | 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 85.92% |
 | 보안 체크리스트 | ✅ | 하드코딩 시크릿 없음, reasoning 입력을 Joi enum으로 검증, 신규 에러 누출 없음 |
 | Docker 이미지 검증 | ⚠️ | OrbStack Docker 소켓이 없어 이미지 빌드 및 컨테이너 내부 `codex --version` 확인은 실행하지 못함 |
-| Pull Request | ✅ | GitHub PR [#1](https://github.com/azuyamat/code-review-worker/pull/1) 생성 |
+| Pull Request | ✅ | GitHub PR [#17](https://github.com/azyu/bitbucket-codex-code-review/pull/17) 생성, CI `lint-and-build` 성공 |
 
 ### Task 27: GPT-5.6 모델 패밀리 호환성 검토
 - **상태**: ✅ 검토 완료 (현재 운영 이미지 기준 미대응)

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -20,6 +20,7 @@
 | 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 85.92% |
 | 보안 체크리스트 | ✅ | 하드코딩 시크릿 없음, reasoning 입력을 Joi enum으로 검증, 신규 에러 누출 없음 |
 | Docker 이미지 검증 | ⚠️ | OrbStack Docker 소켓이 없어 이미지 빌드 및 컨테이너 내부 `codex --version` 확인은 실행하지 못함 |
+| Pull Request | ✅ | GitHub PR [#1](https://github.com/azuyamat/code-review-worker/pull/1) 생성 |
 
 ### Task 27: GPT-5.6 모델 패밀리 호환성 검토
 - **상태**: ✅ 검토 완료 (현재 운영 이미지 기준 미대응)

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ QUEUE_RETRY_DELAY=5000
 # Codex CLI Configuration
 CODEX_BINARY_PATH=codex
 CODEX_TIMEOUT_MS=600000
-CODEX_MODEL=gpt-5.5
+CODEX_MODEL=gpt-5.6-sol
 CODEX_REASONING_EFFORT=medium
 OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://custom-endpoint.example.com/v1

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ coverage/
 .DS_Store
 *.tsbuildinfo
 .claude
+
+.worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache git ca-certificates curl tini
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --prod --frozen-lockfile
 # renovate: datasource=npm depName=@openai/codex
-RUN npm install -g @openai/codex@0.124.0
+RUN npm install -g @openai/codex@0.144.1
 
 COPY --from=build /app/dist ./dist
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ docker compose up -d
 |---|---|---|
 | `CODEX_BINARY_PATH` | Codex CLI 바이너리 경로 | `codex` |
 | `CODEX_MODEL` | 사용 모델 | `gpt-5.6-sol` |
-| `CODEX_REASONING_EFFORT` | 추론 노력도 (`low` / `medium` / `high` / `xhigh`) | `medium` |
+| `CODEX_REASONING_EFFORT` | 추론 노력도 (`none` / `low` / `medium` / `high` / `xhigh` / `max`) | `medium` |
 | `CODEX_TIMEOUT_MS` | 실행 타임아웃 (ms) | `600000` |
 | `OPENAI_API_KEY` | OpenAI API 키 (Codex CLI 인증) | - |
 | `OPENAI_BASE_URL` | OpenAI API 엔드포인트 URL (커스텀 엔드포인트용) | - |

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ docker compose up -d
 | 환경변수 | 설명 | 기본값 |
 |---|---|---|
 | `CODEX_BINARY_PATH` | Codex CLI 바이너리 경로 | `codex` |
-| `CODEX_MODEL` | 사용 모델 | `gpt-5.5` |
+| `CODEX_MODEL` | 사용 모델 | `gpt-5.6-sol` |
 | `CODEX_REASONING_EFFORT` | 추론 노력도 (`low` / `medium` / `high` / `xhigh`) | `medium` |
 | `CODEX_TIMEOUT_MS` | 실행 타임아웃 (ms) | `600000` |
 | `OPENAI_API_KEY` | OpenAI API 키 (Codex CLI 인증) | - |

--- a/charts/code-review-worker/README.md
+++ b/charts/code-review-worker/README.md
@@ -109,7 +109,7 @@ EOF
 | `nodeEnv` | `production` | NODE_ENV |
 | `port` | `3000` | HTTP 포트 |
 | `metricsPort` | `9463` | 메트릭 포트 |
-| `codex.model` | `gpt-5.5` | Codex 모델 |
+| `codex.model` | `gpt-5.6-sol` | Codex 모델 |
 | `codex.timeoutMs` | `600000` | Codex 타임아웃 (ms) |
 | `codex.reasoningEffort` | `medium` | Codex reasoning 수준 |
 | `codexAuth.existingSecret` | `""` | Codex 인증 Secret 이름 |

--- a/charts/code-review-worker/values.yaml
+++ b/charts/code-review-worker/values.yaml
@@ -63,7 +63,7 @@ queue:
 codex:
   binaryPath: codex
   timeoutMs: 600000
-  model: gpt-5.5
+  model: gpt-5.6-sol
   reasoningEffort: medium
 
 # --- Bitbucket ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
       CODEX_BINARY_PATH: codex
       CODEX_TIMEOUT_MS: 600000
-      CODEX_MODEL: gpt-5.5
+      CODEX_MODEL: gpt-5.6-sol
       CODEX_REASONING_EFFORT: medium
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}

--- a/docs/superpowers/plans/2026-07-10-gpt-5-6-compatibility.md
+++ b/docs/superpowers/plans/2026-07-10-gpt-5-6-compatibility.md
@@ -1,0 +1,391 @@
+# GPT-5.6 Compatibility Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the worker officially compatible with GPT-5.6, use `gpt-5.6-sol` by default, and reject unsupported reasoning configuration before jobs start.
+
+**Architecture:** Preserve the existing environment-to-`CodexService` data flow. Upgrade the container's Codex CLI, move all active model defaults together, add Joi validation at the existing configuration boundary, and characterize exact model forwarding with focused Jest coverage.
+
+**Tech Stack:** NestJS 11, TypeScript 5.9, Joi 17, Jest 29, Docker, Helm 4
+
+## Global Constraints
+
+- Pin `@openai/codex` to `0.144.1`; OpenAI documents `0.144.0` as the GPT-5.6 minimum.
+- Set the default model to `gpt-5.6-sol` on every active runtime, deployment, test, and documentation surface.
+- Continue accepting `CODEX_MODEL` as an opaque string; do not add a model allowlist.
+- Accept only `none`, `low`, `medium`, `high`, `xhigh`, and `max` for `CODEX_REASONING_EFFORT`.
+- Keep `medium` as the default reasoning effort.
+- Do not add runtime version probes, model-catalog subprocesses, model routing, Pro mode, multi-agent mode, or prompt changes.
+- Preserve queue, database, Bitbucket, workspace, and review output contracts.
+
+---
+
+### Task 1: Upgrade the Container Codex CLI
+
+**Files:**
+- Modify: `Dockerfile:35-36`
+
+**Interfaces:**
+- Consumes: npm package `@openai/codex@0.144.1`
+- Produces: container command `codex` with GPT-5.6 support
+
+- [ ] **Step 1: Update the pinned package version**
+
+Change the runtime installation to:
+
+```dockerfile
+# renovate: datasource=npm depName=@openai/codex
+RUN npm install -g @openai/codex@0.144.1
+```
+
+- [ ] **Step 2: Build the runtime image**
+
+Run:
+
+```bash
+docker build -t code-review-worker:gpt-5.6-cli .
+```
+
+Expected: exit code `0`. If the Docker daemon is unavailable, record the exact daemon error and continue with the non-Docker checks; do not claim the image was verified.
+
+- [ ] **Step 3: Verify the CLI inside the image**
+
+Run:
+
+```bash
+docker run --rm --entrypoint codex code-review-worker:gpt-5.6-cli --version
+```
+
+Expected output:
+
+```text
+codex-cli 0.144.1
+```
+
+- [ ] **Step 4: Commit the CLI upgrade**
+
+```bash
+git add Dockerfile
+git commit -m "build: upgrade codex cli to 0.144.1"
+```
+
+---
+
+### Task 2: Move Active Defaults to GPT-5.6 Sol
+
+**Files:**
+- Modify: `src/config/configuration.spec.ts:1-61`
+- Modify: `src/config/configuration.ts:14-17`
+- Modify: `src/webhook/webhook.controller.spec.ts:43-46,101-104,157-163,184-189`
+- Modify: `.env.example:25-29`
+- Modify: `docker-compose.yml:39-42`
+- Modify: `charts/code-review-worker/values.yaml:62-67`
+- Modify: `README.md:105-115`
+- Modify: `charts/code-review-worker/README.md:104-115`
+
+**Interfaces:**
+- Consumes: environment variable `CODEX_MODEL`
+- Produces: `DEFAULTS.CODEX_MODEL === "gpt-5.6-sol"` and matching deployment defaults
+
+- [ ] **Step 1: Write a failing default-configuration test**
+
+Change the import and add a separate default-configuration test:
+
+```typescript
+import configuration, { parseJsonRecord } from "./configuration";
+
+describe("configuration", () => {
+  const originalCodexModel = process.env["CODEX_MODEL"];
+
+  afterEach(() => {
+    if (originalCodexModel === undefined) {
+      delete process.env["CODEX_MODEL"];
+    } else {
+      process.env["CODEX_MODEL"] = originalCodexModel;
+    }
+  });
+
+  it("defaults Codex to GPT-5.6 Sol", () => {
+    delete process.env["CODEX_MODEL"];
+
+    const config = configuration();
+
+    expect(config).toEqual(
+      expect.objectContaining({
+        codex: expect.objectContaining({ model: "gpt-5.6-sol" }),
+      }),
+    );
+  });
+});
+```
+
+Keep the existing `parseJsonRecord` tests unchanged.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+pnpm test --runInBand src/config/configuration.spec.ts
+```
+
+Expected: FAIL because the actual default is `gpt-5.5`.
+
+- [ ] **Step 3: Change the application default**
+
+In `src/config/configuration.ts`, set:
+
+```typescript
+CODEX_MODEL: "gpt-5.6-sol",
+```
+
+- [ ] **Step 4: Update deployment and documentation defaults**
+
+Replace active `gpt-5.5` defaults with `gpt-5.6-sol` in:
+
+```text
+.env.example
+docker-compose.yml
+charts/code-review-worker/values.yaml
+README.md
+charts/code-review-worker/README.md
+```
+
+Do not change historical entries in `.context/TASKS.md`.
+
+- [ ] **Step 5: Update user-visible progress-message fixtures**
+
+In `src/webhook/webhook.controller.spec.ts`, set the mock model and expected progress messages to `gpt-5.6-sol`:
+
+```typescript
+"codex.model": "gpt-5.6-sol",
+```
+
+Expected message fragments:
+
+```text
+- Model: gpt-5.6-sol
+- Reasoning: high
+```
+
+and:
+
+```text
+- Model: gpt-5.6-sol
+```
+
+- [ ] **Step 6: Verify the new default and progress output**
+
+Run:
+
+```bash
+pnpm test --runInBand src/config/configuration.spec.ts src/webhook/webhook.controller.spec.ts
+```
+
+Expected: both suites PASS.
+
+- [ ] **Step 7: Render the default Helm ConfigMap**
+
+Run:
+
+```bash
+helm template review-worker charts/code-review-worker --show-only templates/configmap.yaml
+```
+
+Expected rendered field:
+
+```yaml
+CODEX_MODEL: "gpt-5.6-sol"
+```
+
+- [ ] **Step 8: Commit the default migration**
+
+```bash
+git add src/config/configuration.ts src/config/configuration.spec.ts src/webhook/webhook.controller.spec.ts .env.example docker-compose.yml charts/code-review-worker/values.yaml README.md charts/code-review-worker/README.md
+git commit -m "feat: default reviews to gpt-5.6-sol"
+```
+
+---
+
+### Task 3: Validate GPT-5.6 Reasoning Effort
+
+**Files:**
+- Modify: `src/config/validation.spec.ts:3-81`
+- Modify: `src/config/validation.ts:42-45`
+- Modify: `README.md:109-112`
+
+**Interfaces:**
+- Consumes: `CODEX_REASONING_EFFORT` environment string
+- Produces: a validated value in `none | low | medium | high | xhigh | max`, defaulting to `medium`
+
+- [ ] **Step 1: Write the failing rejection test**
+
+Add to `src/config/validation.spec.ts`:
+
+```typescript
+it("rejects unsupported Codex reasoning effort", () => {
+  const { error } = validationSchema.validate({
+    ...validEnv,
+    CODEX_REASONING_EFFORT: "ultra",
+  });
+
+  expect(error?.message).toContain("CODEX_REASONING_EFFORT");
+});
+```
+
+- [ ] **Step 2: Run the rejection test and verify RED**
+
+Run:
+
+```bash
+pnpm test --runInBand src/config/validation.spec.ts
+```
+
+Expected: FAIL because the current schema allows the unknown environment key through.
+
+- [ ] **Step 3: Add Joi validation**
+
+In `src/config/validation.ts`, add directly after `CODEX_MODEL`:
+
+```typescript
+CODEX_REASONING_EFFORT: Joi.string()
+  .valid("none", "low", "medium", "high", "xhigh", "max")
+  .default(DEFAULTS.CODEX_REASONING_EFFORT),
+```
+
+- [ ] **Step 4: Add allowed-value and default coverage**
+
+Update the existing default assertion:
+
+```typescript
+expect(value).toEqual(
+  expect.objectContaining({
+    PORT: 3000,
+    CODEX_BINARY_PATH: "codex",
+    CODEX_MODEL: "gpt-5.6-sol",
+    CODEX_REASONING_EFFORT: "medium",
+    BITBUCKET_REPO_TOKENS: "",
+    REVIEW_TRIGGER_MODE: "mention",
+  }),
+);
+```
+
+Add a table-driven test:
+
+```typescript
+it.each(["none", "low", "medium", "high", "xhigh", "max"])(
+  "accepts Codex reasoning effort %s",
+  (reasoningEffort) => {
+    const { error, value } = validationSchema.validate({
+      ...validEnv,
+      CODEX_REASONING_EFFORT: reasoningEffort,
+    });
+
+    expect(error).toBeUndefined();
+    expect(value.CODEX_REASONING_EFFORT).toBe(reasoningEffort);
+  },
+);
+```
+
+- [ ] **Step 5: Document the accepted values**
+
+Set the root README description to:
+
+```text
+추론 노력도 (`none` / `low` / `medium` / `high` / `xhigh` / `max`)
+```
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+pnpm test --runInBand src/config/validation.spec.ts
+```
+
+Expected: PASS, including the rejection and all six accepted values.
+
+- [ ] **Step 7: Commit reasoning validation**
+
+```bash
+git add src/config/validation.ts src/config/validation.spec.ts README.md
+git commit -m "feat: validate codex reasoning effort"
+```
+
+---
+
+### Task 4: Add GPT-5.6 Model Forwarding Regression Coverage
+
+**Files:**
+- Modify: `src/codex/codex.service.spec.ts:68-128`
+
+**Interfaces:**
+- Consumes: `codex.model` and `codex.reasoningEffort` from `ConfigService`
+- Produces: exact `spawn` argv coverage for the GPT-5.6 alias and three explicit variants
+
+- [ ] **Step 1: Add parameterized forwarding coverage**
+
+Add inside `describe("CodexService", ...)`:
+
+```typescript
+it.each([
+  "gpt-5.6",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+])("forwards GPT-5.6 model %s to Codex", async (model) => {
+  const child = createMockChild();
+  spawnSpy.mockReturnValue(child);
+  readFileSpy.mockResolvedValue("review output text");
+
+  const promise = createService({
+    "codex.model": model,
+    "codex.reasoningEffort": "medium",
+  }).executeCodex("/work", "main", "review this");
+
+  child.emit("close", 0, null);
+  await promise;
+
+  const [, args] = spawnSpy.mock.calls[0] as [string, string[]];
+  const modelArgIndex = args.indexOf("--model");
+  const configArgIndex = args.indexOf("-c");
+
+  expect(modelArgIndex).toBeGreaterThan(-1);
+  expect(args[modelArgIndex + 1]).toBe(model);
+  expect(configArgIndex).toBeGreaterThan(-1);
+  expect(args[configArgIndex + 1]).toBe(
+    'model_reasoning_effort="medium"',
+  );
+});
+```
+
+This is characterization coverage for the existing opaque-model forwarding contract; it is expected to pass immediately and requires no production-code change.
+
+- [ ] **Step 2: Run the focused Codex tests**
+
+Run:
+
+```bash
+pnpm test --runInBand src/codex/codex.service.spec.ts
+```
+
+Expected: PASS for all existing tests plus four model cases.
+
+- [ ] **Step 3: Render each explicit Helm override**
+
+Run:
+
+```bash
+helm template review-worker charts/code-review-worker --set codex.model=gpt-5.6-sol --show-only templates/configmap.yaml
+helm template review-worker charts/code-review-worker --set codex.model=gpt-5.6-terra --show-only templates/configmap.yaml
+helm template review-worker charts/code-review-worker --set codex.model=gpt-5.6-luna --show-only templates/configmap.yaml
+```
+
+Expected: each output contains the exact selected `CODEX_MODEL` value and `CODEX_REASONING_EFFORT: "medium"`.
+
+- [ ] **Step 4: Commit forwarding coverage**
+
+```bash
+git add src/codex/codex.service.spec.ts
+git commit -m "test: cover gpt-5.6 model forwarding"
+```

--- a/docs/superpowers/specs/2026-07-10-gpt-5-6-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-10-gpt-5-6-compatibility-design.md
@@ -1,0 +1,104 @@
+# GPT-5.6 Compatibility Migration Design
+
+## Goal
+
+Make the worker officially compatible with the GPT-5.6 model family while preserving the existing review pipeline and its default `medium` reasoning behavior.
+
+The default review model will change from `gpt-5.5` to `gpt-5.6-sol`. Operators may override it with `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna` through the existing `CODEX_MODEL` setting.
+
+## Scope
+
+1. Pin the container runtime to `@openai/codex@0.144.1`, which is above OpenAI's documented GPT-5.6 minimum of `0.144.0`.
+2. Change every active default and deployment example from `gpt-5.5` to `gpt-5.6-sol`.
+3. Validate `CODEX_REASONING_EFFORT` at application startup.
+4. Add regression coverage for GPT-5.6 model forwarding and reasoning validation.
+5. Verify the rendered Helm configuration and the existing review pipeline.
+
+## Non-Goals
+
+- No startup call to `codex --version`.
+- No startup call to `codex debug models`.
+- No account-specific model availability check.
+- No dynamic model router or per-repository model selection.
+- No Pro mode, persisted reasoning, multi-agent, or prompt changes.
+- No change to queue, database, Bitbucket, workspace, or review output contracts.
+
+## Design
+
+### Codex Runtime
+
+`Dockerfile` remains the single source of truth for the container's Codex CLI version. The pinned package changes from `0.124.0` to `0.144.1`. Non-container deployments continue to own the `codex` binary selected by `CODEX_BINARY_PATH`; the application will not add a runtime version probe.
+
+### Model Defaults
+
+The following active defaults move together to `gpt-5.6-sol`:
+
+- `DEFAULTS.CODEX_MODEL`
+- `.env.example`
+- `docker-compose.yml`
+- Helm `values.yaml`
+- root README
+- chart README
+- tests that assert user-visible progress messages
+
+The application will continue treating `CODEX_MODEL` as an opaque string and passing it as one `spawn` argument after `--model`. This preserves support for future model IDs without introducing a repository-side model allowlist.
+
+### Reasoning Validation
+
+`CODEX_REASONING_EFFORT` will be added to the Joi environment schema with these GPT-5.6 values:
+
+- `none`
+- `low`
+- `medium`
+- `high`
+- `xhigh`
+- `max`
+
+The default remains `medium`. An unsupported or malformed value will fail application configuration validation before any review job starts. Model-specific availability remains Codex/OpenAI's responsibility.
+
+### Execution Flow
+
+The runtime flow remains unchanged:
+
+```text
+CODEX_MODEL + CODEX_REASONING_EFFORT
+  -> Nest configuration
+  -> CodexService
+  -> codex exec --model <model> -c model_reasoning_effort="<effort>"
+```
+
+No additional subprocess or network request is introduced.
+
+## Error Handling
+
+- Invalid `CODEX_REASONING_EFFORT`: application startup fails through the existing Joi validation path.
+- Unavailable model for the authenticated account: the existing non-zero Codex exit handling records stderr and fails the review job.
+- Missing or incompatible non-container Codex binary: existing spawn error handling remains authoritative.
+
+## Testing
+
+### Focused Tests
+
+- Parameterized `CodexService` test for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, asserting exact `--model` argv forwarding.
+- Validation tests that accept all six documented reasoning values.
+- Validation test that rejects an unsupported reasoning value.
+- Existing progress-message tests updated to the new default model.
+
+### Deployment Checks
+
+- Render the Helm ConfigMap for Sol, Terra, and Luna overrides.
+- Build the Docker image and verify `codex --version` reports at least `0.144.0` when the local Docker daemon is available.
+
+### Definition of Done
+
+- `pnpm build`
+- `pnpm lint`
+- `pnpm test --runInBand`
+- `pnpm test:cov --runInBand` with statement coverage at least 80%
+- No hardcoded secret, external-input expansion, or additional error leakage
+- `.context/TASKS.md` updated
+- Conventional commit created
+
+## Rollback
+
+Revert the default model surfaces to `gpt-5.5` and the Docker CLI pin to `0.124.0`. No data migration or compatibility shim is required because model and reasoning settings are environment-driven strings.

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -103,6 +103,36 @@ describe("CodexService", () => {
     expect(rmSpy).toHaveBeenCalled();
   });
 
+  it.each([
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+  ])("forwards GPT-5.6 model %s to Codex", async (model) => {
+    const child = createMockChild();
+    spawnSpy.mockReturnValue(child);
+    readFileSpy.mockResolvedValue("review output text");
+
+    const promise = createService({
+      "codex.model": model,
+      "codex.reasoningEffort": "medium",
+    }).executeCodex("/work", "main", "review this");
+
+    child.emit("close", 0, null);
+    await promise;
+
+    const [, args] = spawnSpy.mock.calls[0] as [string, string[]];
+    const modelArgIndex = args.indexOf("--model");
+    const configArgIndex = args.indexOf("-c");
+
+    expect(modelArgIndex).toBeGreaterThan(-1);
+    expect(args[modelArgIndex + 1]).toBe(model);
+    expect(configArgIndex).toBeGreaterThan(-1);
+    expect(args[configArgIndex + 1]).toBe(
+      'model_reasoning_effort="medium"',
+    );
+  });
+
   it("should pass prompt through stdin instead of argv to avoid E2BIG", async () => {
     const child = createMockChild();
     spawnSpy.mockReturnValue(child);

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,4 +1,28 @@
-import { parseJsonRecord } from "./configuration";
+import configuration, { parseJsonRecord } from "./configuration";
+
+describe("configuration", () => {
+  const originalCodexModel = process.env["CODEX_MODEL"];
+
+  afterEach(() => {
+    if (originalCodexModel === undefined) {
+      delete process.env["CODEX_MODEL"];
+    } else {
+      process.env["CODEX_MODEL"] = originalCodexModel;
+    }
+  });
+
+  it("defaults Codex to GPT-5.6 Sol", () => {
+    delete process.env["CODEX_MODEL"];
+
+    const config = configuration();
+
+    expect(config).toEqual(
+      expect.objectContaining({
+        codex: expect.objectContaining({ model: "gpt-5.6-sol" }),
+      }),
+    );
+  });
+});
 
 describe("parseJsonRecord", () => {
   let warnSpy: jest.SpyInstance;

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -13,7 +13,7 @@ export const DEFAULTS = {
   QUEUE_RETRY_DELAY: 5000,
   CODEX_BINARY_PATH: "codex",
   CODEX_TIMEOUT_MS: 600_000,
-  CODEX_MODEL: "gpt-5.5",
+  CODEX_MODEL: "gpt-5.6-sol",
   CODEX_REASONING_EFFORT: "medium",
   REVIEW_CUSTOM_PROMPT_FILEPATH: "",
   BITBUCKET_BASE_URL: "https://api.bitbucket.org/2.0",

--- a/src/config/validation.spec.ts
+++ b/src/config/validation.spec.ts
@@ -21,6 +21,8 @@ describe("validationSchema", () => {
       expect.objectContaining({
         PORT: 3000,
         CODEX_BINARY_PATH: "codex",
+        CODEX_MODEL: "gpt-5.6-sol",
+        CODEX_REASONING_EFFORT: "medium",
         BITBUCKET_REPO_TOKENS: "",
         REVIEW_TRIGGER_MODE: "mention",
       }),
@@ -70,6 +72,31 @@ describe("validationSchema", () => {
 
     expect(error?.message).toContain("REVIEW_TRIGGER_MODE");
   });
+
+  it("rejects unsupported Codex reasoning effort", () => {
+    const { error } = validationSchema.validate(
+      {
+        ...validEnv,
+        CODEX_REASONING_EFFORT: "ultra",
+      },
+      { allowUnknown: true },
+    );
+
+    expect(error?.message).toContain("CODEX_REASONING_EFFORT");
+  });
+
+  it.each(["none", "low", "medium", "high", "xhigh", "max"])(
+    "accepts Codex reasoning effort %s",
+    (reasoningEffort) => {
+      const { error, value } = validationSchema.validate({
+        ...validEnv,
+        CODEX_REASONING_EFFORT: reasoningEffort,
+      });
+
+      expect(error).toBeUndefined();
+      expect(value.CODEX_REASONING_EFFORT).toBe(reasoningEffort);
+    },
+  );
 
   it("requires NODE_ENV", () => {
     const { NODE_ENV: _nodeEnv, ...envWithoutNodeEnv } = validEnv;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -42,6 +42,9 @@ export const validationSchema = Joi.object({
   CODEX_BINARY_PATH: Joi.string().default(DEFAULTS.CODEX_BINARY_PATH),
   CODEX_TIMEOUT_MS: Joi.number().default(DEFAULTS.CODEX_TIMEOUT_MS),
   CODEX_MODEL: Joi.string().default(DEFAULTS.CODEX_MODEL),
+  CODEX_REASONING_EFFORT: Joi.string()
+    .valid("none", "low", "medium", "high", "xhigh", "max")
+    .default(DEFAULTS.CODEX_REASONING_EFFORT),
   BITBUCKET_BASE_URL: Joi.string().default(DEFAULTS.BITBUCKET_BASE_URL),
   BITBUCKET_API_TOKEN: Joi.string().allow("").default(""),
   BITBUCKET_REPO_TOKENS: Joi.string()

--- a/src/webhook/webhook.controller.spec.ts
+++ b/src/webhook/webhook.controller.spec.ts
@@ -42,7 +42,7 @@ describe("WebhookController", () => {
   };
   const configValues: Record<string, unknown> = {
     "trigger.mode": "mention",
-    "codex.model": "gpt-5.5",
+    "codex.model": "gpt-5.6-sol",
     "codex.reasoningEffort": "high",
   };
   const configService = {
@@ -100,7 +100,7 @@ describe("WebhookController", () => {
     jest.clearAllMocks();
     Object.assign(configValues, {
       "trigger.mode": "mention",
-      "codex.model": "gpt-5.5",
+      "codex.model": "gpt-5.6-sol",
       "codex.reasoningEffort": "high",
     });
     reviewQueue.getJob.mockResolvedValue(null);
@@ -159,7 +159,7 @@ describe("WebhookController", () => {
       repoSlug: "repo-a",
       pullRequestId: 17,
       parentCommentId: 321,
-      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.5\n- Reasoning: high",
+      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.6-sol\n- Reasoning: high",
     });
   });
 
@@ -185,7 +185,7 @@ describe("WebhookController", () => {
       workspace: "workspace",
       repoSlug: "repo-a",
       pullRequestId: 17,
-      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.5",
+      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.6-sol",
     });
   });
 


### PR DESCRIPTION
## Summary

- Codex CLI를 GPT-5.6 공식 최소 버전 이상인 `0.144.1`로 업그레이드
- 기본 리뷰 모델을 `gpt-5.6-sol`로 전환하고 env, Compose, Helm, README 기본값 동기화
- `CODEX_REASONING_EFFORT`를 `none`/`low`/`medium`/`high`/`xhigh`/`max`로 검증
- `gpt-5.6`, Sol, Terra, Luna의 Codex argv 전달 회귀 테스트 추가

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm test --runInBand` — 187 tests passed
- `pnpm test:cov --runInBand` — statement coverage 85.92%
- `helm lint charts/code-review-worker`
- `docker compose config --quiet`
- 기본/Sol/Terra/Luna Helm ConfigMap 렌더링 확인
- 독립 코드 리뷰: blocking finding 없음

## Known limitation

- OrbStack Docker 소켓이 없어 이미지 빌드와 컨테이너 내부 `codex --version` 확인은 수행하지 못했습니다. Dockerfile은 `@openai/codex@0.144.1`로 고정되어 있고 npm 레지스트리에서 해당 버전 존재를 확인했습니다.