### PR TITLE
feat: add per-repo custom review prompt mapping

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -360,3 +360,14 @@
 | helm lint 통과 | ✅ | 0 chart(s) failed |
 | helm template 렌더링 | ✅ | 정상 출력 확인 |
 | pnpm build + test | ✅ | 42 tests passed |
+
+### repo별 커스텀 리뷰 프롬프트 매핑
+- **상태**: ✅ 완료
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS 설정 추가 | ✅ | configuration.ts, parseJsonRecord 재사용 (slug→filepath JSON 맵) |
+| executeReview repo별 프롬프트 해석 | ✅ | repoMap[slug] → REVIEW_CUSTOM_PROMPT_FILEPATH fallback |
+| 테스트 (TDD RED→GREEN) | ✅ | 맵 매칭/전역 fallback/파일 누락 reject 3케이스, 190 tests passed |
+| 문서 업데이트 | ✅ | README.md env 테이블, .env.example |
+| pnpm build + lint + test:cov | ✅ | 커버리지 85.93% (기준 80%) |

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -371,3 +371,4 @@
 | 테스트 (TDD RED→GREEN) | ✅ | 맵 매칭/전역 fallback/파일 누락 reject 3케이스, 190 tests passed |
 | 문서 업데이트 | ✅ | README.md env 테이블, .env.example |
 | pnpm build + lint + test:cov | ✅ | 커버리지 85.93% (기준 80%) |
+| PR #18 Codex 리뷰 반영 | ✅ | validation.ts에 jsonObjectValidator 추가 (부팅 시 fail-fast), 192 tests passed |

--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://custom-endpoint.example.com/v1
 
 # Custom Review Prompt (optional, appended to base prompt)
+# Per-repo mapping (repo slug → filepath) takes precedence; unmapped repos fall back to REVIEW_CUSTOM_PROMPT_FILEPATH
+# REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS='{"frontend-app":"/prompts/javascript_guidelines.md","api-server":"/prompts/backend_guidelines.md"}'
 # REVIEW_CUSTOM_PROMPT_FILEPATH=/path/to/custom-prompt.md
 
 # Bitbucket Configuration

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ docker compose up -d
 | `CODEX_TIMEOUT_MS` | 실행 타임아웃 (ms) | `600000` |
 | `OPENAI_API_KEY` | OpenAI API 키 (Codex CLI 인증) | - |
 | `OPENAI_BASE_URL` | OpenAI API 엔드포인트 URL (커스텀 엔드포인트용) | - |
-| `REVIEW_CUSTOM_PROMPT_FILEPATH` | 커스텀 리뷰 프롬프트 파일 경로 (기본 프롬프트에 append) | - |
+| `REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS` | repo slug별 커스텀 프롬프트 파일 경로 JSON 맵 (예: `{"frontend-app":"/prompts/js.md"}`). 매핑된 repo에 우선 적용 | - |
+| `REVIEW_CUSTOM_PROMPT_FILEPATH` | 전역 커스텀 리뷰 프롬프트 파일 경로 (기본 프롬프트에 append). repo별 매핑이 없는 repo의 fallback | - |
 
 ### Bitbucket
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -82,6 +82,7 @@ export default (): Record<string, unknown> => ({
     model: process.env["CODEX_MODEL"] || DEFAULTS.CODEX_MODEL,
     reasoningEffort: process.env["CODEX_REASONING_EFFORT"] || DEFAULTS.CODEX_REASONING_EFFORT,
     customPromptFilepath: process.env["REVIEW_CUSTOM_PROMPT_FILEPATH"] || DEFAULTS.REVIEW_CUSTOM_PROMPT_FILEPATH,
+    repoCustomPromptFilepaths: parseJsonRecord(process.env["REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS"], "REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS"),
   },
   bitbucket: {
     baseUrl: process.env["BITBUCKET_BASE_URL"] || DEFAULTS.BITBUCKET_BASE_URL,

--- a/src/config/validation.spec.ts
+++ b/src/config/validation.spec.ts
@@ -64,6 +64,29 @@ describe("validationSchema", () => {
     );
   });
 
+  it("accepts repo custom prompt filepath JSON objects", () => {
+    const { error, value } = validationSchema.validate({
+      ...validEnv,
+      REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS: '{"repo-a":"/prompts/a.md"}',
+    });
+
+    expect(error).toBeUndefined();
+    expect(value.REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS).toBe(
+      '{"repo-a":"/prompts/a.md"}',
+    );
+  });
+
+  it("rejects invalid repo custom prompt filepath JSON", () => {
+    const { error } = validationSchema.validate({
+      ...validEnv,
+      REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS: "{invalid}",
+    });
+
+    expect(error?.message).toContain(
+      "Invalid REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS",
+    );
+  });
+
   it("rejects unsupported trigger modes", () => {
     const { error } = validationSchema.validate({
       ...validEnv,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -45,6 +45,10 @@ export const validationSchema = Joi.object({
   CODEX_REASONING_EFFORT: Joi.string()
     .valid("none", "low", "medium", "high", "xhigh", "max")
     .default(DEFAULTS.CODEX_REASONING_EFFORT),
+  REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS: Joi.string()
+    .allow("")
+    .default("")
+    .custom(jsonObjectValidator("REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS")),
   BITBUCKET_BASE_URL: Joi.string().default(DEFAULTS.BITBUCKET_BASE_URL),
   BITBUCKET_API_TOKEN: Joi.string().allow("").default(""),
   BITBUCKET_REPO_TOKENS: Joi.string()

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -640,6 +640,7 @@ describe("ReviewProcessor publish results", () => {
       worktreePath: string,
       baseBranch: string,
       reviewDiff: string,
+      repositorySlug: string,
     ): Promise<ICodexReviewResult>;
   };
 
@@ -661,6 +662,7 @@ describe("ReviewProcessor publish results", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockConfigService.get.mockReturnValue("");
     mockWorkspaceService.createReviewDiff.mockResolvedValue(
       "diff --git a/src/app.ts b/src/app.ts\n+++ b/src/app.ts\n@@ -1,1 +1,1 @@\n+new line",
     );
@@ -709,6 +711,7 @@ describe("ReviewProcessor publish results", () => {
         "/worktree",
         "main",
         reviewDiff,
+        "my-repo",
       );
 
       const prompt = mockCodexService.executeCodex.mock.calls[0][2];
@@ -743,7 +746,7 @@ describe("ReviewProcessor publish results", () => {
       await writeFile(tmpFile, customPrompt);
 
       try {
-        mockConfigService.get.mockImplementationOnce(
+        mockConfigService.get.mockImplementation(
           (key: string, defaultValue?: string) =>
             key === "codex.customPromptFilepath"
               ? tmpFile
@@ -772,6 +775,7 @@ describe("ReviewProcessor publish results", () => {
           "/worktree",
           "main",
           reviewDiff,
+          "my-repo",
         );
 
         const prompt = mockCodexService.executeCodex.mock.calls[0][2];
@@ -782,6 +786,102 @@ describe("ReviewProcessor publish results", () => {
       } finally {
         await rm(tmpFile, { force: true });
       }
+    });
+
+    it("should append per-repo custom prompt when repository slug is mapped", async () => {
+      const tmpFile = `/tmp/test-repo-prompt-${Date.now()}.md`;
+      await writeFile(tmpFile, "REPO_SPECIFIC_GUIDELINE_MARKER");
+
+      try {
+        mockConfigService.get.mockImplementation(
+          (key: string, defaultValue?: string) =>
+            key === "codex.repoCustomPromptFilepaths"
+              ? { "my-repo": tmpFile }
+              : defaultValue ?? "",
+        );
+        mockCodexService.executeCodex.mockResolvedValueOnce({
+          rawOutput: '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+          exitCode: 0,
+          durationMs: 1,
+          inputTokens: null,
+          cachedInputTokens: null,
+          outputTokens: null,
+        });
+
+        await (processor as unknown as ReviewProcessorWithExecuteReview).executeReview(
+          "/worktree",
+          "main",
+          "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n+ok",
+          "my-repo",
+        );
+
+        const prompt = mockCodexService.executeCodex.mock.calls[0][2];
+        expect(prompt).toContain("## 추가 리뷰 지시사항");
+        expect(prompt).toContain("REPO_SPECIFIC_GUIDELINE_MARKER");
+      } finally {
+        await rm(tmpFile, { force: true });
+      }
+    });
+
+    it("should fall back to global custom prompt when repository slug is not mapped", async () => {
+      const repoFile = `/tmp/test-repo-prompt-other-${Date.now()}.md`;
+      const globalFile = `/tmp/test-global-prompt-${Date.now()}.md`;
+      await writeFile(repoFile, "OTHER_REPO_MARKER");
+      await writeFile(globalFile, "GLOBAL_GUIDELINE_MARKER");
+
+      try {
+        mockConfigService.get.mockImplementation(
+          (key: string, defaultValue?: string) => {
+            if (key === "codex.repoCustomPromptFilepaths") {
+              return { "other-repo": repoFile };
+            }
+            if (key === "codex.customPromptFilepath") {
+              return globalFile;
+            }
+            return defaultValue ?? "";
+          },
+        );
+        mockCodexService.executeCodex.mockResolvedValueOnce({
+          rawOutput: '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+          exitCode: 0,
+          durationMs: 1,
+          inputTokens: null,
+          cachedInputTokens: null,
+          outputTokens: null,
+        });
+
+        await (processor as unknown as ReviewProcessorWithExecuteReview).executeReview(
+          "/worktree",
+          "main",
+          "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n+ok",
+          "my-repo",
+        );
+
+        const prompt = mockCodexService.executeCodex.mock.calls[0][2];
+        expect(prompt).toContain("GLOBAL_GUIDELINE_MARKER");
+        expect(prompt).not.toContain("OTHER_REPO_MARKER");
+      } finally {
+        await rm(repoFile, { force: true });
+        await rm(globalFile, { force: true });
+      }
+    });
+
+    it("should reject when the mapped per-repo prompt file is missing", async () => {
+      mockConfigService.get.mockImplementation(
+        (key: string, defaultValue?: string) =>
+          key === "codex.repoCustomPromptFilepaths"
+            ? { "my-repo": "/nonexistent/repo-prompt.md" }
+            : defaultValue ?? "",
+      );
+
+      await expect(
+        (processor as unknown as ReviewProcessorWithExecuteReview).executeReview(
+          "/worktree",
+          "main",
+          "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n+ok",
+          "my-repo",
+        ),
+      ).rejects.toThrow(/Failed to read custom prompt file/);
     });
   });
 
@@ -991,6 +1091,7 @@ describe("ReviewProcessor error handling", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockConfigService.get.mockReturnValue("");
     mockWorkspaceService.createReviewDiff.mockResolvedValue(
       "diff --git a/src/app.ts b/src/app.ts\n+++ b/src/app.ts\n@@ -1,1 +1,1 @@\n+new line",
     );

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -63,6 +63,7 @@ export class ReviewProcessor extends WorkerHost {
         worktreePath,
         data.baseBranch,
         reviewDiff,
+        data.repositorySlug,
       );
 
       // Step 3: Publish results to Bitbucket
@@ -170,11 +171,16 @@ export class ReviewProcessor extends WorkerHost {
     worktreePath: string,
     baseBranch: string,
     reviewDiff: string,
+    repositorySlug: string,
   ): Promise<ICodexReviewResult> {
-    const customPromptFilepath = this.configService.get<string>(
-      "codex.customPromptFilepath",
-      "",
-    );
+    // Resolve prompt file: repoCustomPromptFilepaths[repoSlug] → customPromptFilepath
+    const repoCustomPromptFilepaths =
+      this.configService.get<Record<string, string>>(
+        "codex.repoCustomPromptFilepaths",
+      ) ?? {};
+    const customPromptFilepath =
+      repoCustomPromptFilepaths[repositorySlug] ||
+      this.configService.get<string>("codex.customPromptFilepath", "");
     let reviewPromptMode: ReviewPromptMode =
       reviewDiff.length > MAX_INLINE_REVIEW_PROMPT_CHARS
         ? "branch-diff"


### PR DESCRIPTION
## Summary

단일 워커 인스턴스에서 여러 repo의 리뷰를 받을 때, repo(slug)별로 다른 커스텀 리뷰 프롬프트 파일을 적용할 수 있도록 `REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS`(slug→파일경로 JSON 맵)를 추가한다.

## Changes

- **`src/config/configuration.ts`**: `REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS` env를 기존 `parseJsonRecord`로 파싱 (`BITBUCKET_REPO_TOKENS`와 동일 패턴)
- **`src/queue/review.processor.ts`**: `executeReview()`에 `repositorySlug` 전달, 프롬프트 파일 해석 우선순위: `repoMap[slug]` → 전역 `REVIEW_CUSTOM_PROMPT_FILEPATH` → 없음
- **`review.prompt.ts` 무변경**: 매핑된 파일 읽기 실패 시 리뷰 잡이 명시적으로 실패하는 기존 fail-loud 동작 유지
- **문서**: README env 테이블, `.env.example`에 우선순위·JSON 예시 추가

## Usage

```bash
REVIEW_REPO_CUSTOM_PROMPT_FILEPATHS='{"frontend-app":"/prompts/javascript_guidelines.md","api-server":"/prompts/backend_guidelines.md"}'
```

## Test

- TDD(RED→GREEN): 맵 매칭 / 전역 fallback / 파일 누락 reject 3케이스 추가
- `pnpm build` · `pnpm lint` · `pnpm test` 190/190 통과, 커버리지 85.93%

## Out of Scope

- 디렉토리 컨벤션(`<dir>/<slug>.md`) — repo 수십 개 규모가 되면 재검토
- Helm 차트 env 등재 — 기존 `REVIEW_CUSTOM_PROMPT_FILEPATH`도 미등재(별도 주입 방식)로 현행 유지