### PR TITLE
fix: surface excluded lock file changes in review prompt

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -385,3 +385,4 @@
 | 테스트 | ✅ | workspace 3케이스 + 프롬프트 4케이스 + process() 배선 1케이스, 199 tests passed |
 | pnpm build + lint + test:cov | ✅ | 커버리지 86.7% (기준 80%) |
 | 실물 검증 | ✅ | `171df0940`에 positive pathspec 실행 → `M pnpm-lock.yaml` 출력 확인 |
+| PR #19 Codex 리뷰 반영 (P2 2건) | ✅ | ① 조회 실패를 `null`(알 수 없음)로 구분해 "변경 없음" 단정 제거 ② 상태값(M/A/D/R) 설명 추가로 lock 삭제·이름 변경은 계속 지적 가능, 201 tests passed |

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -372,3 +372,16 @@
 | 문서 업데이트 | ✅ | README.md env 테이블, .env.example |
 | pnpm build + lint + test:cov | ✅ | 커버리지 85.93% (기준 80%) |
 | PR #18 Codex 리뷰 반영 | ✅ | validation.ts에 jsonObjectValidator 추가 (부팅 시 fail-fast), 192 tests passed |
+
+### lock 파일 제외로 인한 리뷰 오탐 제거
+- **상태**: ✅ 완료
+- **배경**: lxp_services `171df0940` 리뷰에서 "pnpm-lock.yaml 갱신 없음" blocking 오탐 발생. 실제로는 3535줄 변경됨. `REVIEW_DIFF_EXCLUDED_PATHS`가 lock 파일을 diff에서 제거하는데, 프롬프트가 그 사실을 모델에게 알려주지 않아 "diff에 없음 = 변경 없음"으로 오독됨.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| createReviewDiff가 IReviewDiff 반환 | ✅ | diff + excludedChangedFiles (`git diff --name-status`, exclude pathspec을 positive로 반전) |
+| 제외 목록 조회 실패 시 degrade | ✅ | warn 로그 후 빈 배열, 리뷰는 계속 진행 |
+| 프롬프트에 "diff에서 제외된 변경 파일" 섹션 | ✅ | inline-diff/branch-diff 두 모드 공통, 목록 없으면 "변경된 파일 없음"으로 명시해 진짜 lock 미갱신은 계속 지적 가능 |
+| 테스트 | ✅ | workspace 3케이스 + 프롬프트 4케이스 + process() 배선 1케이스, 199 tests passed |
+| pnpm build + lint + test:cov | ✅ | 커버리지 86.7% (기준 80%) |
+| 실물 검증 | ✅ | `171df0940`에 positive pathspec 실행 → `M pnpm-lock.yaml` 출력 확인 |

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ coverage/
 .DS_Store
 *.tsbuildinfo
 .claude
+.serena/
 
 .worktrees/

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -48,6 +48,37 @@ describe("review.prompt", () => {
     },
   );
 
+  describe("excluded changed files section", () => {
+    it.each(["inline-diff", "branch-diff"] as const)(
+      "should list excluded but changed files in %s mode",
+      (mode) => {
+        const prompt = buildReviewPrompt("main", "diff --git a/a b/a", mode, [
+          "M pnpm-lock.yaml",
+        ]);
+
+        expect(prompt).toContain("## diff에서 제외된 변경 파일");
+        expect(prompt).toContain("- M pnpm-lock.yaml");
+        expect(prompt).toContain('"변경되지 않았다"');
+      },
+    );
+
+    it("should state that no excluded file changed when the list is empty", () => {
+      const prompt = buildReviewPrompt("main", "diff --git a/a b/a");
+
+      expect(prompt).toContain("## diff에서 제외된 변경 파일");
+      expect(prompt).toContain("그중 변경된 파일이 없어");
+      expect(prompt).not.toContain("- M pnpm-lock.yaml");
+    });
+
+    it("should forward excluded files through resolveReviewPrompt", async () => {
+      const result = await resolveReviewPrompt("main", "", "diff", "inline-diff", [
+        "M pnpm-lock.yaml",
+      ]);
+
+      expect(result).toContain("- M pnpm-lock.yaml");
+    });
+  });
+
   describe("resolveReviewPrompt", () => {
     it("should return default prompt when filepath is empty", async () => {
       const result = await resolveReviewPrompt("main", "");
@@ -641,6 +672,7 @@ describe("ReviewProcessor publish results", () => {
       baseBranch: string,
       reviewDiff: string,
       repositorySlug: string,
+      excludedChangedFiles: readonly string[],
     ): Promise<ICodexReviewResult>;
   };
 
@@ -663,9 +695,10 @@ describe("ReviewProcessor publish results", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockConfigService.get.mockReturnValue("");
-    mockWorkspaceService.createReviewDiff.mockResolvedValue(
-      "diff --git a/src/app.ts b/src/app.ts\n+++ b/src/app.ts\n@@ -1,1 +1,1 @@\n+new line",
-    );
+    mockWorkspaceService.createReviewDiff.mockResolvedValue({
+      diff: "diff --git a/src/app.ts b/src/app.ts\n+++ b/src/app.ts\n@@ -1,1 +1,1 @@\n+new line",
+      excludedChangedFiles: [],
+    });
     processor = new ReviewProcessor(
       mockReviewService as never,
       mockWorkspaceService as never,
@@ -712,6 +745,7 @@ describe("ReviewProcessor publish results", () => {
         "main",
         reviewDiff,
         "my-repo",
+        [],
       );
 
       const prompt = mockCodexService.executeCodex.mock.calls[0][2];
@@ -776,6 +810,7 @@ describe("ReviewProcessor publish results", () => {
           "main",
           reviewDiff,
           "my-repo",
+          [],
         );
 
         const prompt = mockCodexService.executeCodex.mock.calls[0][2];
@@ -813,6 +848,7 @@ describe("ReviewProcessor publish results", () => {
           "main",
           "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n+ok",
           "my-repo",
+          [],
         );
 
         const prompt = mockCodexService.executeCodex.mock.calls[0][2];
@@ -855,6 +891,7 @@ describe("ReviewProcessor publish results", () => {
           "main",
           "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n+ok",
           "my-repo",
+          [],
         );
 
         const prompt = mockCodexService.executeCodex.mock.calls[0][2];
@@ -880,6 +917,7 @@ describe("ReviewProcessor publish results", () => {
           "main",
           "diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n+ok",
           "my-repo",
+          [],
         ),
       ).rejects.toThrow(/Failed to read custom prompt file/);
     });
@@ -928,6 +966,32 @@ describe("ReviewProcessor publish results", () => {
       expect.objectContaining({
         body: expect.not.stringContaining("1) 변경 개요"),
       }),
+    );
+  });
+
+  it("should forward excluded changed files from the review diff into the Codex prompt", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/worktree",
+      bareRepoPath: "/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockWorkspaceService.createReviewDiff.mockResolvedValue({
+      diff: "diff --git a/package.json b/package.json\n@@ -1 +1 @@\n+dep",
+      excludedChangedFiles: ["M pnpm-lock.yaml"],
+    });
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput: '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+      exitCode: 0,
+      durationMs: 1,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+
+    await processor.process({ data: baseJobData } as never);
+
+    expect(mockCodexService.executeCodex.mock.calls[0][2]).toContain(
+      "- M pnpm-lock.yaml",
     );
   });
 
@@ -1092,9 +1156,10 @@ describe("ReviewProcessor error handling", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockConfigService.get.mockReturnValue("");
-    mockWorkspaceService.createReviewDiff.mockResolvedValue(
-      "diff --git a/src/app.ts b/src/app.ts\n+++ b/src/app.ts\n@@ -1,1 +1,1 @@\n+new line",
-    );
+    mockWorkspaceService.createReviewDiff.mockResolvedValue({
+      diff: "diff --git a/src/app.ts b/src/app.ts\n+++ b/src/app.ts\n@@ -1,1 +1,1 @@\n+new line",
+      excludedChangedFiles: [],
+    });
     processor = new ReviewProcessor(
       mockReviewService as never,
       mockWorkspaceService as never,

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -70,6 +70,32 @@ describe("review.prompt", () => {
       expect(prompt).not.toContain("- M pnpm-lock.yaml");
     });
 
+    it("should not claim absence when the excluded file lookup failed", () => {
+      const prompt = buildReviewPrompt(
+        "main",
+        "diff --git a/a b/a",
+        "inline-diff",
+        null,
+      );
+
+      expect(prompt).toContain("목록을 조회하지 못해서");
+      expect(prompt).toContain("lock 갱신 누락 여부는 판단하지 말고");
+      expect(prompt).not.toContain("그중 변경된 파일이 없어");
+    });
+
+    it("should allow reporting deleted lock files while explaining status codes", () => {
+      const prompt = buildReviewPrompt(
+        "main",
+        "diff --git a/package.json b/package.json",
+        "inline-diff",
+        ["D pnpm-lock.yaml"],
+      );
+
+      expect(prompt).toContain("- D pnpm-lock.yaml");
+      expect(prompt).toContain("M=수정, A=추가, D=삭제, R=이름 변경");
+      expect(prompt).toContain("D/R처럼 삭제·이름 변경 상태라면");
+    });
+
     it("should forward excluded files through resolveReviewPrompt", async () => {
       const result = await resolveReviewPrompt("main", "", "diff", "inline-diff", [
         "M pnpm-lock.yaml",
@@ -672,7 +698,7 @@ describe("ReviewProcessor publish results", () => {
       baseBranch: string,
       reviewDiff: string,
       repositorySlug: string,
-      excludedChangedFiles: readonly string[],
+      excludedChangedFiles: readonly string[] | null,
     ): Promise<ICodexReviewResult>;
   };
 

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -53,10 +53,12 @@ export class ReviewProcessor extends WorkerHost {
       const worktreeInfo = await this.prepareWorkspace(data);
       worktreePath = worktreeInfo.worktreePath;
       bareRepoPath = worktreeInfo.bareRepoPath;
-      reviewDiff = await this.workspaceService.createReviewDiff(
-        worktreePath,
-        data.baseBranch,
-      );
+      const { diff, excludedChangedFiles } =
+        await this.workspaceService.createReviewDiff(
+          worktreePath,
+          data.baseBranch,
+        );
+      reviewDiff = diff;
 
       // Step 2: Execute unified review (single Codex call)
       codexResult = await this.executeReview(
@@ -64,6 +66,7 @@ export class ReviewProcessor extends WorkerHost {
         data.baseBranch,
         reviewDiff,
         data.repositorySlug,
+        excludedChangedFiles,
       );
 
       // Step 3: Publish results to Bitbucket
@@ -172,6 +175,7 @@ export class ReviewProcessor extends WorkerHost {
     baseBranch: string,
     reviewDiff: string,
     repositorySlug: string,
+    excludedChangedFiles: readonly string[],
   ): Promise<ICodexReviewResult> {
     // Resolve prompt file: repoCustomPromptFilepaths[repoSlug] → customPromptFilepath
     const repoCustomPromptFilepaths =
@@ -195,6 +199,7 @@ export class ReviewProcessor extends WorkerHost {
       customPromptFilepath,
       reviewDiff,
       reviewPromptMode,
+      excludedChangedFiles,
     );
     if (
       reviewPromptMode === "inline-diff" &&
@@ -209,6 +214,7 @@ export class ReviewProcessor extends WorkerHost {
         customPromptFilepath,
         reviewDiff,
         reviewPromptMode,
+        excludedChangedFiles,
       );
     }
 

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -175,7 +175,7 @@ export class ReviewProcessor extends WorkerHost {
     baseBranch: string,
     reviewDiff: string,
     repositorySlug: string,
-    excludedChangedFiles: readonly string[],
+    excludedChangedFiles: readonly string[] | null,
   ): Promise<ICodexReviewResult> {
     // Resolve prompt file: repoCustomPromptFilepaths[repoSlug] → customPromptFilepath
     const repoCustomPromptFilepaths =

--- a/src/queue/review.prompt.ts
+++ b/src/queue/review.prompt.ts
@@ -17,7 +17,7 @@ export async function resolveReviewPrompt(
   customPromptFilepath: string,
   reviewDiff = "",
   mode: ReviewPromptMode = "inline-diff",
-  excludedChangedFiles: readonly string[] = [],
+  excludedChangedFiles: readonly string[] | null = [],
 ): Promise<string> {
   const base = buildReviewPrompt(
     baseBranch,
@@ -40,37 +40,59 @@ export async function resolveReviewPrompt(
   }
 }
 
+/**
+ * diff 본문에서 제외한 파일에 대한 안내 섹션.
+ * null은 "조회 실패로 알 수 없음" — 변경 없음으로 단정하면 안 된다.
+ */
+function buildExcludedSection(
+  excludedChangedFiles: readonly string[] | null,
+): string[] {
+  const heading = ["## diff에서 제외된 변경 파일", ""];
+
+  if (excludedChangedFiles === null) {
+    return [
+      ...heading,
+      "제외 대상 파일(lock 파일) 목록을 조회하지 못해서, 이번 PR에서 lock 파일이 바뀌었는지 알 수 없어.",
+      "lock 갱신 누락 여부는 판단하지 말고 findings에도 포함하지 마.",
+      "",
+    ];
+  }
+
+  if (excludedChangedFiles.length === 0) {
+    return [
+      ...heading,
+      "lock 파일(pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb)은 diff 본문에서 항상 제외되지만, 이번 PR에서는 그중 변경된 파일이 없어.",
+      "의존성 매니페스트 변경에 lock 갱신이 빠졌다고 지적할 경우, path는 반드시 diff에 포함된 파일(예: package.json)로 지정해줘.",
+      "",
+    ];
+  }
+
+  return [
+    ...heading,
+    "아래 파일들은 이번 PR에서 실제로 변경됐지만, 입력 크기를 줄이려고 diff 본문에서 의도적으로 제외했어.",
+    "",
+    ...excludedChangedFiles.map((file) => `- ${file}`),
+    "",
+    "각 줄 앞 문자는 `git diff --name-status` 상태값이야 (M=수정, A=추가, D=삭제, R=이름 변경).",
+    'M/A 상태 파일은 정상적으로 갱신된 것이니 "변경되지 않았다" / "갱신이 누락됐다"고 단정하지 마.',
+    "D/R처럼 삭제·이름 변경 상태라면 문제가 될 수 있으니 필요하면 지적해도 돼.",
+    "단 findings의 path는 반드시 diff에 포함된 파일(예: package.json)로 지정해줘 — 제외된 파일 경로로 단 findings는 게시 단계에서 폐기돼.",
+    "",
+  ];
+}
+
 export function buildReviewPrompt(
   baseBranch: string,
   reviewDiff = "",
   mode: ReviewPromptMode = "inline-diff",
-  excludedChangedFiles: readonly string[] = [],
+  excludedChangedFiles: readonly string[] | null = [],
 ): string {
   const isBranchDiffMode = mode === "branch-diff";
   const quotedBaseRef = shellQuote(`refs/heads/${baseBranch}`);
   const targetInstruction = isBranchDiffMode
     ? "프롬프트에 diff를 첨부하지 않는다. 현재 worktree의 체크아웃된 브랜치에서 Git으로 PR diff를 직접 조회하고, 조회한 변경사항만 근거로 사용해줘."
     : "반드시 이 프롬프트 하단의 `리뷰 대상 PR diff`만 근거로 사용해줘.";
-  const excludedSection =
-    excludedChangedFiles.length > 0
-      ? [
-          "## diff에서 제외된 변경 파일",
-          "",
-          "아래 파일들은 이번 PR에서 실제로 변경됐지만, 입력 크기를 줄이려고 diff 본문에서 의도적으로 제외했어.",
-          "",
-          ...excludedChangedFiles.map((file) => `- ${file}`),
-          "",
-          '이 파일들이 "변경되지 않았다" / "갱신이 누락됐다"고 단정하지 마.',
-          "이 파일들 자체에 대한 findings도 만들지 마 (게시 단계에서 폐기됨).",
-          "",
-        ]
-      : [
-          "## diff에서 제외된 변경 파일",
-          "",
-          "lock 파일(pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb)은 diff 본문에서 항상 제외되지만, 이번 PR에서는 그중 변경된 파일이 없어.",
-          "의존성 매니페스트 변경에 lock 갱신이 빠졌다고 지적할 경우, path는 반드시 diff에 포함된 파일(예: package.json)로 지정해줘.",
-          "",
-        ];
+  const excludedSection = buildExcludedSection(excludedChangedFiles);
   const diffSection = isBranchDiffMode
     ? [
         "## 리뷰 대상 PR diff",

--- a/src/queue/review.prompt.ts
+++ b/src/queue/review.prompt.ts
@@ -17,8 +17,14 @@ export async function resolveReviewPrompt(
   customPromptFilepath: string,
   reviewDiff = "",
   mode: ReviewPromptMode = "inline-diff",
+  excludedChangedFiles: readonly string[] = [],
 ): Promise<string> {
-  const base = buildReviewPrompt(baseBranch, reviewDiff, mode);
+  const base = buildReviewPrompt(
+    baseBranch,
+    reviewDiff,
+    mode,
+    excludedChangedFiles,
+  );
 
   if (!customPromptFilepath) {
     return base;
@@ -38,12 +44,33 @@ export function buildReviewPrompt(
   baseBranch: string,
   reviewDiff = "",
   mode: ReviewPromptMode = "inline-diff",
+  excludedChangedFiles: readonly string[] = [],
 ): string {
   const isBranchDiffMode = mode === "branch-diff";
   const quotedBaseRef = shellQuote(`refs/heads/${baseBranch}`);
   const targetInstruction = isBranchDiffMode
     ? "프롬프트에 diff를 첨부하지 않는다. 현재 worktree의 체크아웃된 브랜치에서 Git으로 PR diff를 직접 조회하고, 조회한 변경사항만 근거로 사용해줘."
     : "반드시 이 프롬프트 하단의 `리뷰 대상 PR diff`만 근거로 사용해줘.";
+  const excludedSection =
+    excludedChangedFiles.length > 0
+      ? [
+          "## diff에서 제외된 변경 파일",
+          "",
+          "아래 파일들은 이번 PR에서 실제로 변경됐지만, 입력 크기를 줄이려고 diff 본문에서 의도적으로 제외했어.",
+          "",
+          ...excludedChangedFiles.map((file) => `- ${file}`),
+          "",
+          '이 파일들이 "변경되지 않았다" / "갱신이 누락됐다"고 단정하지 마.',
+          "이 파일들 자체에 대한 findings도 만들지 마 (게시 단계에서 폐기됨).",
+          "",
+        ]
+      : [
+          "## diff에서 제외된 변경 파일",
+          "",
+          "lock 파일(pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lockb)은 diff 본문에서 항상 제외되지만, 이번 PR에서는 그중 변경된 파일이 없어.",
+          "의존성 매니페스트 변경에 lock 갱신이 빠졌다고 지적할 경우, path는 반드시 diff에 포함된 파일(예: package.json)로 지정해줘.",
+          "",
+        ];
   const diffSection = isBranchDiffMode
     ? [
         "## 리뷰 대상 PR diff",
@@ -166,6 +193,7 @@ export function buildReviewPrompt(
     '  - "tech-debt": 향후 개선이 필요한 기술 부채',
     "- 문제가 없으면 빈 배열 []",
     "",
+    ...excludedSection,
     ...diffSection,
   ].join("\n");
 }

--- a/src/workspace/interfaces/workspace.interfaces.ts
+++ b/src/workspace/interfaces/workspace.interfaces.ts
@@ -7,8 +7,11 @@ export interface IWorktreeInfo {
 export interface IReviewDiff {
   /** 리뷰 대상 unified diff (lock 파일 등 제외 경로는 빠져 있음) */
   readonly diff: string;
-  /** diff에서 제외됐지만 실제로 변경된 파일 목록 (예: "M pnpm-lock.yaml") */
-  readonly excludedChangedFiles: readonly string[];
+  /**
+   * diff에서 제외됐지만 실제로 변경된 파일 목록 (예: "M pnpm-lock.yaml").
+   * null이면 조회 실패로 "변경 여부를 알 수 없음" — 빈 배열(변경 없음)과 구분한다.
+   */
+  readonly excludedChangedFiles: readonly string[] | null;
 }
 
 export interface IPrepareWorktreeParams {

--- a/src/workspace/interfaces/workspace.interfaces.ts
+++ b/src/workspace/interfaces/workspace.interfaces.ts
@@ -4,6 +4,13 @@ export interface IWorktreeInfo {
   readonly bareRepoPath: string;
 }
 
+export interface IReviewDiff {
+  /** 리뷰 대상 unified diff (lock 파일 등 제외 경로는 빠져 있음) */
+  readonly diff: string;
+  /** diff에서 제외됐지만 실제로 변경된 파일 목록 (예: "M pnpm-lock.yaml") */
+  readonly excludedChangedFiles: readonly string[];
+}
+
 export interface IPrepareWorktreeParams {
   readonly cloneUrl: string;
   readonly repositorySlug: string;

--- a/src/workspace/workspace.service.spec.ts
+++ b/src/workspace/workspace.service.spec.ts
@@ -322,7 +322,7 @@ describe("WorkspaceService", () => {
     expect(result.excludedChangedFiles).toEqual([]);
   });
 
-  it("keeps the diff when listing excluded changed files fails", async () => {
+  it("returns null excluded files when the lookup fails", async () => {
     execFileMock
       .mockImplementationOnce(
         (
@@ -352,7 +352,7 @@ describe("WorkspaceService", () => {
     const result = await service.createReviewDiff("/tmp/worktree", "main");
 
     expect(result.diff).toBe("diff --git a/file b/file");
-    expect(result.excludedChangedFiles).toEqual([]);
+    expect(result.excludedChangedFiles).toBeNull();
   });
 
   it("throws when merge-base returns an empty commit", async () => {

--- a/src/workspace/workspace.service.spec.ts
+++ b/src/workspace/workspace.service.spec.ts
@@ -215,11 +215,27 @@ describe("WorkspaceService", () => {
           _options: Record<string, unknown>,
           callback: ExecFileCallback,
         ) => callback(null, { stdout: "diff --git a/file b/file", stderr: "" }),
+      )
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) =>
+          callback(null, {
+            stdout: "M\tpnpm-lock.yaml\nR100\told.lock\tapps/web/yarn.lock\n",
+            stderr: "",
+          }),
       );
 
-    const diff = await service.createReviewDiff("/tmp/worktree", "main");
+    const result = await service.createReviewDiff("/tmp/worktree", "main");
 
-    expect(diff).toBe("diff --git a/file b/file");
+    expect(result.diff).toBe("diff --git a/file b/file");
+    expect(result.excludedChangedFiles).toEqual([
+      "M pnpm-lock.yaml",
+      "R100 apps/web/yarn.lock",
+    ]);
     expect(execFileMock).toHaveBeenNthCalledWith(
       1,
       "git",
@@ -250,6 +266,93 @@ describe("WorkspaceService", () => {
       },
       expect.any(Function),
     );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      3,
+      "git",
+      [
+        "diff",
+        "--no-ext-diff",
+        "--find-renames",
+        "--name-status",
+        "basecommit123..HEAD",
+        "--",
+        ":(glob)**/pnpm-lock.yaml",
+        ":(glob)**/package-lock.json",
+        ":(glob)**/yarn.lock",
+        ":(glob)**/bun.lockb",
+      ],
+      {
+        cwd: "/tmp/worktree",
+        timeout: 30_000,
+        maxBuffer: 1024 * 1024,
+      },
+      expect.any(Function),
+    );
+  });
+
+  it("returns an empty excluded file list when no lock file changed", async () => {
+    execFileMock
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(null, { stdout: "basecommit123\n", stderr: "" }),
+      )
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(null, { stdout: "diff --git a/file b/file", stderr: "" }),
+      )
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(null, { stdout: "\n", stderr: "" }),
+      );
+
+    const result = await service.createReviewDiff("/tmp/worktree", "main");
+
+    expect(result.excludedChangedFiles).toEqual([]);
+  });
+
+  it("keeps the diff when listing excluded changed files fails", async () => {
+    execFileMock
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(null, { stdout: "basecommit123\n", stderr: "" }),
+      )
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(null, { stdout: "diff --git a/file b/file", stderr: "" }),
+      )
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(new Error("git failed")),
+      );
+
+    const result = await service.createReviewDiff("/tmp/worktree", "main");
+
+    expect(result.diff).toBe("diff --git a/file b/file");
+    expect(result.excludedChangedFiles).toEqual([]);
   });
 
   it("throws when merge-base returns an empty commit", async () => {

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -166,11 +166,12 @@ export class WorkspaceService {
   /**
    * diff 본문에서 제외한 경로 중 이번 PR에서 실제로 변경된 파일 목록.
    * 프롬프트에 명시해 "diff에 없음 = 변경 없음" 오탐을 막는다.
+   * 조회 실패 시 null — 빈 배열(변경 없음)로 단정하면 같은 오탐이 재발한다.
    */
   private async listExcludedChangedFiles(
     worktreePath: string,
     baseCommit: string,
-  ): Promise<string[]> {
+  ): Promise<string[] | null> {
     try {
       const { stdout } = await execFileAsync(
         "git",
@@ -204,7 +205,7 @@ export class WorkspaceService {
       this.logger.warn(
         `Failed to list excluded changed files: ${(err as Error).message}`,
       );
-      return [];
+      return null;
     }
   }
 

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -9,6 +9,7 @@ import { existsSync } from "fs";
 import {
   IWorktreeInfo,
   IPrepareWorktreeParams,
+  IReviewDiff,
 } from "./interfaces/workspace.interfaces";
 
 const execFileAsync = promisify(execFile);
@@ -18,6 +19,12 @@ const REVIEW_DIFF_EXCLUDED_PATHS = [
   "yarn.lock",
   "bun.lockb",
 ];
+const excludePathspecs = REVIEW_DIFF_EXCLUDED_PATHS.map(
+  (path) => `:(exclude,glob)**/${path}`,
+);
+const includePathspecs = REVIEW_DIFF_EXCLUDED_PATHS.map(
+  (path) => `:(glob)**/${path}`,
+);
 
 @Injectable()
 export class WorkspaceService {
@@ -111,7 +118,7 @@ export class WorkspaceService {
   async createReviewDiff(
     worktreePath: string,
     baseBranch: string,
-  ): Promise<string> {
+  ): Promise<IReviewDiff> {
     const baseRef = `refs/heads/${baseBranch}`;
     const { stdout: mergeBase } = await execFileAsync(
       "git",
@@ -136,9 +143,7 @@ export class WorkspaceService {
         `${baseCommit}..HEAD`,
         "--",
         ".",
-        ...REVIEW_DIFF_EXCLUDED_PATHS.map(
-          (path) => `:(exclude,glob)**/${path}`,
-        ),
+        ...excludePathspecs,
       ],
       {
         cwd: worktreePath,
@@ -147,10 +152,60 @@ export class WorkspaceService {
       },
     );
 
+    const excludedChangedFiles = await this.listExcludedChangedFiles(
+      worktreePath,
+      baseCommit,
+    );
+
     this.logger.debug(
       `Review diff created from merge-base ${baseCommit.substring(0, 12)} against HEAD`,
     );
-    return stdout;
+    return { diff: stdout, excludedChangedFiles };
+  }
+
+  /**
+   * diff 본문에서 제외한 경로 중 이번 PR에서 실제로 변경된 파일 목록.
+   * 프롬프트에 명시해 "diff에 없음 = 변경 없음" 오탐을 막는다.
+   */
+  private async listExcludedChangedFiles(
+    worktreePath: string,
+    baseCommit: string,
+  ): Promise<string[]> {
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        [
+          "diff",
+          "--no-ext-diff",
+          "--find-renames",
+          "--name-status",
+          `${baseCommit}..HEAD`,
+          "--",
+          ...includePathspecs,
+        ],
+        {
+          cwd: worktreePath,
+          timeout: 30_000,
+          maxBuffer: 1024 * 1024,
+        },
+      );
+
+      return stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const fields = line.split("\t");
+          const status = fields[0];
+          const path = fields[fields.length - 1];
+          return `${status} ${path}`;
+        });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to list excluded changed files: ${(err as Error).message}`,
+      );
+      return [];
+    }
   }
 
   private async ensureBareRepo(


### PR DESCRIPTION
## 배경

`lxp_services` 커밋 `171df0940` (Nx 22.7.6 → 23.1.0) 리뷰에서 **blocking 오탐**이 발생했다:

> 의존성 변경을 pnpm-lock.yaml에 반영하세요 — package.json은 바뀌었지만 diff에 lockfile 갱신이 없다

실제 커밋에는 `pnpm-lock.yaml`이 3535줄 변경되어 있다.

## 원인

모델 품질 문제가 아니라 컨텍스트 설계 결함이다.

- `REVIEW_DIFF_EXCLUDED_PATHS`가 lock 파일을 `:(exclude,glob)` pathspec으로 diff에서 제거한다 (토큰 절약, 의도된 동작)
- 프롬프트는 "diff에 없는 파일/라인/변경사항은 절대 findings에 포함하지 마"라고만 지시하고 **왜** 없는지는 알려주지 않는다 → 모델이 "부재 = 미변경"으로 읽는 것은 자연스러운 추론
- branch-diff 모드도 같은 exclude pathspec을 bash 명령에 넣으므로 동일 오탐이 재현된다
- 오탐 finding의 `path`가 `package.json`(diff 포함 경로)이라 `filterFindingsToReviewDiff` 경로 필터에도 걸리지 않는다

## 변경

diff 본문은 계속 제외하되, **제외 대상 중 실제로 변경된 파일 목록**을 워커가 계산해 프롬프트에 명시한다.

- `createReviewDiff`가 `IReviewDiff { diff, excludedChangedFiles }` 반환. exclude pathspec을 positive로 반전해 `git diff --name-status` 1회 추가 조회 (`REVIEW_DIFF_EXCLUDED_PATHS` 단일 출처 재사용)
- 조회 실패는 리뷰를 실패시키지 않는다 — warn 로그 후 빈 배열로 degrade
- 프롬프트에 `## diff에서 제외된 변경 파일` 섹션 추가 (inline-diff / branch-diff 공통)
  - 목록 있음: "실제로 변경됐지만 본문만 생략됨. 변경되지 않았다고 단정하지 마"
  - 목록 없음: "그중 변경된 파일이 없어" → **진짜 lock 미갱신 PR은 계속 지적 가능**하고, path는 diff에 포함된 파일로 지정하도록 안내

## 검증

- `pnpm build` exit 0 / `pnpm lint` 경고 0 / `pnpm test` **199 passed** / 커버리지 **86.7%** (기준 80%)
- 테스트 추가: workspace 3케이스(목록 파싱·빈 목록·조회 실패 degrade), 프롬프트 4케이스(양 모드·빈 목록·resolve 전달), `process()` 배선 1케이스
- 실물 확인: 문제의 커밋에 새 pathspec 실행 → `M\tpnpm-lock.yaml` 출력. 이번 변경 이후 프롬프트에 `- M pnpm-lock.yaml`이 실린다

## 남은 위험

프롬프트 지시라 확률적 재발 가능성은 0이 아니다. 다만 lock 파일 경로 finding은 `filterFindingsToReviewDiff`가 이미 폐기하므로, 남는 위험은 "package.json에 붙인 lock 미갱신 지적" 한 가지로 좁혀진다.