### PR TITLE
fix: surface Codex JSON errors

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,8 +1,20 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-07-10
+> 마지막 업데이트: 2026-08-10
 
 ## 진행 중/최근 작업
+
+### Task 29: Codex 실제 실패 메시지 노출
+- **상태**: ✅ 완료
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 실패 원인 추출 | ✅ | `codex exec --json` stdout의 `error`와 `turn.failed` 이벤트에서 실제 오류 메시지 추출 |
+| 사용자 오류 코멘트 전달 | ✅ | stderr가 비어도 추출한 Codex 오류가 기존 실패 코멘트와 DB 오류 메시지 경로로 전달됨 |
+| 회귀 테스트 | ✅ | 두 JSON 오류 이벤트와 Bitbucket 실패 답글의 capacity 메시지 노출 검증 |
+| 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (203 tests) |
+| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 86.75% |
+| 보안 체크리스트 | ✅ | 오류 메시지 64KiB 수집 제한과 사용자 코멘트 500자 제한 유지, 신규 시크릿·입력 경로 없음 |
 
 ### Task 28: GPT-5.6 모델 패밀리 전환
 - **상태**: ✅ 완료

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -10,11 +10,11 @@
 | 서브태스크 | 상태 | 설명 |
 |-----------|------|------|
 | 실패 원인 추출 | ✅ | `codex exec --json` stdout의 `error`와 `turn.failed` 이벤트에서 실제 오류 메시지 추출 |
-| 사용자 오류 코멘트 전달 | ✅ | stderr가 비어도 추출한 Codex 오류가 기존 실패 코멘트와 DB 오류 메시지 경로로 전달됨 |
-| 회귀 테스트 | ✅ | 두 JSON 오류 이벤트와 Bitbucket 실패 답글의 capacity 메시지 노출 검증 |
-| 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (203 tests) |
-| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 86.75% |
-| 보안 체크리스트 | ✅ | 오류 메시지 64KiB 수집 제한과 사용자 코멘트 500자 제한 유지, 신규 시크릿·입력 경로 없음 |
+| 사용자 오류 코멘트 전달 | ✅ | allowlist된 capacity 오류만 기존 실패 코멘트와 DB 오류 메시지 경로로 전달, 나머지는 워커 로그에만 기록 |
+| 회귀 테스트 | ✅ | 두 JSON 오류 이벤트와 Bitbucket capacity 답글을 검증하고 미승인 구조화 오류의 비공개를 검증 |
+| 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (204 tests) |
+| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 86.77% |
+| 보안 체크리스트 | ✅ | 구조화 오류는 capacity 문구만 allowlist, 그 외 메시지는 PR/DB에 노출하지 않음 |
 
 ### Task 28: GPT-5.6 모델 패밀리 전환
 - **상태**: ✅ 완료

--- a/src/codex/codex-output.parser.ts
+++ b/src/codex/codex-output.parser.ts
@@ -17,6 +17,25 @@ function toNullableNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+export function parseCodexErrorLine(line: string): string | null {
+  try {
+    const parsed = JSON.parse(line) as {
+      readonly type?: unknown;
+      readonly message?: unknown;
+      readonly error?: { readonly message?: unknown };
+    };
+    const message =
+      parsed.type === "error"
+        ? parsed.message
+        : parsed.type === "turn.failed"
+          ? parsed.error?.message
+          : null;
+    return typeof message === "string" && message.trim() ? message.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
 const NULL_USAGE: ICodexUsageMetrics = {
   inputTokens: null,
   cachedInputTokens: null,

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -301,6 +301,26 @@ describe("CodexService", () => {
     );
   });
 
+  it("should not publish unrecognized structured error messages", async () => {
+    const child = createMockChild();
+    spawnSpy.mockReturnValue(child);
+    readFileSpy.mockRejectedValue(new Error("ENOENT"));
+
+    const promise = createService().executeCodex("/work", "main", "review");
+
+    child.stdout.emit(
+      "data",
+      `${JSON.stringify({ type: "error", message: "Request failed with api_key=secret" })}\n`,
+    );
+    child.emit("close", 1, null);
+
+    const result = await promise;
+
+    expect(result.rawOutput).toBe(
+      "Codex run failed (exit 1). Check worker logs for details.",
+    );
+  });
+
   it("should throw when output file unreadable on success exit", async () => {
     const child = createMockChild();
     spawnSpy.mockReturnValue(child);

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -278,6 +278,29 @@ describe("CodexService", () => {
     expect(result.inputTokens).toBe(300);
   });
 
+  it.each([
+    { type: "error", message: "Selected model is at capacity. Please try a different model." },
+    {
+      type: "turn.failed",
+      error: { message: "Selected model is at capacity. Please try a different model." },
+    },
+  ])("should return the Codex JSON error message from $type", async (event) => {
+    const child = createMockChild();
+    spawnSpy.mockReturnValue(child);
+    readFileSpy.mockRejectedValue(new Error("ENOENT"));
+
+    const promise = createService().executeCodex("/work", "main", "review");
+
+    child.stdout.emit("data", `${JSON.stringify(event)}\n`);
+    child.emit("close", 1, null);
+
+    const result = await promise;
+
+    expect(result.rawOutput).toBe(
+      "Codex run failed (exit 1): Selected model is at capacity. Please try a different model.",
+    );
+  });
+
   it("should throw when output file unreadable on success exit", async () => {
     const child = createMockChild();
     spawnSpy.mockReturnValue(child);

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -12,6 +12,8 @@ import {
 } from "./codex-output.parser";
 
 const MAX_STDERR_BYTES = 64 * 1024;
+const CAPACITY_ERROR_MESSAGE =
+  "Selected model is at capacity. Please try a different model.";
 const TIMEOUT_EXIT_CODE = 124;
 const CODEX_ENV_DENYLIST = new Set(["CODEX_AUTH_JSON"]);
 
@@ -19,6 +21,7 @@ interface ISpawnResult {
   readonly code: number;
   readonly usage: ICodexUsageMetrics;
   readonly stderr: string;
+  readonly codexError: string;
 }
 
 @Injectable()
@@ -162,16 +165,14 @@ export class CodexService {
           ? TIMEOUT_EXIT_CODE
           : (code ?? 1);
 
-        // For spawn startup failures (ENOENT, EACCES), inject the error
-        // message into stderr so operators see the root cause.
         const stderrOut = stderr.slice(0, MAX_STDERR_BYTES);
-        const finalStderr =
-          stderrOut || codexError.slice(0, MAX_STDERR_BYTES) || spawnError?.message || "";
+        const finalStderr = stderrOut || spawnError?.message || "";
 
         resolve({
           code: exitCode,
           usage: lastUsage,
           stderr: finalStderr,
+          codexError: codexError.slice(0, MAX_STDERR_BYTES),
         });
       });
     });
@@ -207,7 +208,7 @@ export class CodexService {
         this.logger.log(`Codex review completed in ${durationMs}ms`);
       } else {
         this.logger.error(
-          `Codex review failed in ${durationMs}ms (exit ${result.code}): ${result.stderr || "no stderr"}`,
+          `Codex review failed in ${durationMs}ms (exit ${result.code}): ${result.codexError || result.stderr || "no error details"}`,
         );
       }
 
@@ -218,8 +219,12 @@ export class CodexService {
         if (result.code === 0) {
           throw new Error("Codex output file could not be read");
         }
-        rawOutput = result.stderr
-          ? `Codex run failed (exit ${result.code}): ${result.stderr.trim()}`
+        const publicError =
+          result.codexError === CAPACITY_ERROR_MESSAGE
+            ? result.codexError
+            : result.stderr;
+        rawOutput = publicError
+          ? `Codex run failed (exit ${result.code}): ${publicError.trim()}`
           : `Codex run failed (exit ${result.code}). Check worker logs for details.`;
       }
 

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -7,6 +7,7 @@ import { join } from "path";
 import { ICodexReviewResult } from "./interfaces/codex.interfaces";
 import {
   ICodexUsageMetrics,
+  parseCodexErrorLine,
   parseCodexUsageLine,
 } from "./codex-output.parser";
 
@@ -108,6 +109,7 @@ export class CodexService {
       };
       let stderr = "";
       let spawnError: Error | null = null;
+      let codexError = "";
 
       child.stdout.on("data", (chunk: string) => {
         const text = partialLine + chunk;
@@ -118,6 +120,10 @@ export class CodexService {
           const usage = parseCodexUsageLine(line);
           if (usage) {
             lastUsage = usage;
+          }
+          const error = parseCodexErrorLine(line);
+          if (error) {
+            codexError = error;
           }
         }
       });
@@ -146,6 +152,10 @@ export class CodexService {
           if (usage) {
             lastUsage = usage;
           }
+          const error = parseCodexErrorLine(partialLine);
+          if (error) {
+            codexError = error;
+          }
         }
 
         const exitCode = signal
@@ -155,9 +165,8 @@ export class CodexService {
         // For spawn startup failures (ENOENT, EACCES), inject the error
         // message into stderr so operators see the root cause.
         const stderrOut = stderr.slice(0, MAX_STDERR_BYTES);
-        const finalStderr = spawnError && !stderrOut
-          ? spawnError.message
-          : stderrOut;
+        const finalStderr =
+          stderrOut || codexError.slice(0, MAX_STDERR_BYTES) || spawnError?.message || "";
 
         resolve({
           code: exitCode,

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -1248,7 +1248,8 @@ describe("ReviewProcessor error handling", () => {
     });
     mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
     mockCodexService.executeCodex.mockResolvedValue({
-      rawOutput: "codex failed",
+      rawOutput:
+        "Codex run failed (exit 2): Selected model is at capacity. Please try a different model.",
       exitCode: 2,
       durationMs: 2200,
       inputTokens: 1500,
@@ -1270,6 +1271,13 @@ describe("ReviewProcessor error handling", () => {
         outputTokens: 50,
         totalDurationMs: expect.any(Number),
         errorMessage: expect.stringContaining("Codex run failed"),
+      }),
+    );
+    expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "Selected model is at capacity. Please try a different model.",
+        ),
       }),
     );
   });


### PR DESCRIPTION
## Summary
- extract error messages from Codex `error` and `turn.failed` JSONL events
- surface the actual backend failure in PR failure comments and stored review errors
- cover capacity failures through Codex service and processor tests

## Verification
- `pnpm lint`
- `pnpm build`
- `pnpm test --runInBand` (203 tests)
- `pnpm test:cov --runInBand` (86.75% statements)