### PR TITLE
fix: isolate Codex child environment

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -15,7 +15,7 @@
 | 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (204 tests) |
 | 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 86.77% |
 | 보안 체크리스트 | ✅ | 하드코딩 시크릿 없음, 서비스 비밀은 Codex 환경에서 제외, 신규 입력·오류 노출 경로 없음 |
-| PR #21 리뷰 보완 | ✅ | `CODEX_HOME`과 HTTP(S) proxy/`NO_PROXY`, CA 인증서 경로 및 대소문자 proxy 변형을 Codex 자식 환경에 유지하고 회귀 테스트로 검증 |
+| PR #21 리뷰 보완 | ✅ | `CODEX_HOME`과 HTTP(S) proxy/`NO_PROXY`, CA 인증서 경로 및 대소문자 proxy 변형을 Codex 자식 환경에 유지하고 allowlist 변수의 CR/LF 값은 계속 차단하도록 회귀 테스트로 검증 |
 
 ### Task 32: 게시 후 상태 기록 실패 중복 리뷰 차단
 - **상태**: ✅ 완료

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -4,6 +4,18 @@
 
 ## 진행 중/최근 작업
 
+### Task 30: Codex 자식 프로세스 환경 격리
+- **상태**: ✅ 완료
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 취약점 재검증 | ✅ | Codex 실행 환경이 denylist 외의 모든 워커 환경 변수를 상속하는 상태 확인 |
+| 환경 변수 허용 목록 | ✅ | Codex 실행에 필요한 런타임·인증 변수만 명시적으로 전달하고 DB/Redis/Bitbucket/webhook 등 서비스 변수를 차단 |
+| 회귀 테스트 | ✅ | DB 비밀번호와 Bitbucket 토큰이 자식 환경에서 제거되고 Codex 인증 변수는 유지됨을 검증 |
+| 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (204 tests) |
+| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 86.77% |
+| 보안 체크리스트 | ✅ | 하드코딩 시크릿 없음, 서비스 비밀은 Codex 환경에서 제외, 신규 입력·오류 노출 경로 없음 |
+
 ### Task 29: Codex 실제 실패 메시지 노출
 - **상태**: ✅ 완료
 

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -12,8 +12,8 @@
 | 취약점 재검증 | ✅ | Codex 실행 환경이 denylist 외의 모든 워커 환경 변수를 상속하는 상태 확인 |
 | 환경 변수 허용 목록 | ✅ | Codex 실행에 필요한 런타임·인증 변수만 명시적으로 전달하고 DB/Redis/Bitbucket/webhook 등 서비스 변수를 차단 |
 | 회귀 테스트 | ✅ | DB 비밀번호와 Bitbucket 토큰이 자식 환경에서 제거되고 Codex 인증 변수는 유지됨을 검증 |
-| 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (204 tests) |
-| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 86.77% |
+| 빌드/린트/테스트 | ✅ | `pnpm lint`, `pnpm build`, `pnpm test --runInBand` 성공 (240 tests) |
+| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 88.03% |
 | 보안 체크리스트 | ✅ | 하드코딩 시크릿 없음, 서비스 비밀은 Codex 환경에서 제외, 신규 입력·오류 노출 경로 없음 |
 | PR #21 리뷰 보완 | ✅ | `CODEX_HOME`과 HTTP(S) proxy/`NO_PROXY`, CA 인증서 경로 및 대소문자 proxy 변형을 Codex 자식 환경에 유지하고 allowlist 변수의 CR/LF 값은 계속 차단하도록 회귀 테스트로 검증 |
 

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -15,6 +15,7 @@
 | 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공 (204 tests) |
 | 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement coverage 86.77% |
 | 보안 체크리스트 | ✅ | 하드코딩 시크릿 없음, 서비스 비밀은 Codex 환경에서 제외, 신규 입력·오류 노출 경로 없음 |
+| PR #21 리뷰 보완 | ✅ | `CODEX_HOME`과 HTTP(S) proxy/`NO_PROXY`, CA 인증서 경로 및 대소문자 proxy 변형을 Codex 자식 환경에 유지하고 회귀 테스트로 검증 |
 
 ### Task 29: Codex 실제 실패 메시지 노출
 - **상태**: ✅ 완료

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -207,6 +207,38 @@ describe("CodexService", () => {
       delete process.env["DB_PASSWORD"];
     }
   });
+  it.each(["codex-credential\n", "codex-credential\r"])(
+    "should reject multiline values from allowlisted env (%j)",
+    async (multilineValue) => {
+      const child = createMockChild();
+      spawnSpy.mockReturnValue(child);
+      readFileSpy.mockResolvedValue("review output text");
+      const originalValue = process.env["OPENAI_API_KEY"];
+      process.env["OPENAI_API_KEY"] = multilineValue;
+
+      try {
+        const promise = createService().executeCodex("/work", "main", "review");
+
+        child.emit("close", 0, null);
+
+        await promise;
+
+        const [, , options] = spawnSpy.mock.calls[0] as [
+          string,
+          string[],
+          { env: NodeJS.ProcessEnv },
+        ];
+        expect(options.env["OPENAI_API_KEY"]).toBeUndefined();
+      } finally {
+        if (originalValue === undefined) {
+          delete process.env["OPENAI_API_KEY"];
+        } else {
+          process.env["OPENAI_API_KEY"] = originalValue;
+        }
+      }
+    },
+  );
+
 
   it("should handle large JSONL streams without crashing", async () => {
     const child = createMockChild();

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -156,12 +156,13 @@ describe("CodexService", () => {
     expect(child.stdin.end).toHaveBeenCalledWith(largePrompt);
   });
 
-  it("should not pass multiline auth env to codex child process", async () => {
+  it("should only pass allowlisted env to codex child process", async () => {
     const child = createMockChild();
     spawnSpy.mockReturnValue(child);
     readFileSpy.mockResolvedValue("review output text");
-    process.env["CODEX_AUTH_JSON"] = '{\n  "auth_mode": "chatgpt"\n}';
-    process.env["CODEX_SAFE_ENV"] = "safe-value";
+    process.env["BITBUCKET_API_TOKEN"] = "bitbucket-secret";
+    process.env["DB_PASSWORD"] = "database-secret";
+    process.env["OPENAI_API_KEY"] = "codex-credential";
 
     try {
       const promise = createService().executeCodex("/work", "main", "review");
@@ -175,11 +176,13 @@ describe("CodexService", () => {
         string[],
         { env: NodeJS.ProcessEnv },
       ];
-      expect(options.env["CODEX_AUTH_JSON"]).toBeUndefined();
-      expect(options.env["CODEX_SAFE_ENV"]).toBe("safe-value");
+      expect(options.env["BITBUCKET_API_TOKEN"]).toBeUndefined();
+      expect(options.env["DB_PASSWORD"]).toBeUndefined();
+      expect(options.env["OPENAI_API_KEY"]).toBe("codex-credential");
     } finally {
-      delete process.env["CODEX_AUTH_JSON"];
-      delete process.env["CODEX_SAFE_ENV"];
+      delete process.env["BITBUCKET_API_TOKEN"];
+      delete process.env["DB_PASSWORD"];
+      delete process.env["OPENAI_API_KEY"];
     }
   });
 

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -160,9 +160,25 @@ describe("CodexService", () => {
     const child = createMockChild();
     spawnSpy.mockReturnValue(child);
     readFileSpy.mockResolvedValue("review output text");
+    const expectedEnv = {
+      CODEX_HOME: "/custom/codex",
+      HTTP_PROXY: "http://proxy.example",
+      HTTPS_PROXY: "http://secure-proxy.example",
+      NO_PROXY: "localhost,127.0.0.1",
+      SSL_CERT_FILE: "/etc/ssl/cert.pem",
+      SSL_CERT_DIR: "/etc/ssl/certs",
+      http_proxy: "http://lowercase-proxy.example",
+      https_proxy: "http://lowercase-secure-proxy.example",
+      no_proxy: "localhost",
+      OPENAI_API_KEY: "codex-credential",
+      OPENAI_BASE_URL: "https://api.example.com/v1",
+    };
+    const originalEnv = Object.fromEntries(
+      Object.keys(expectedEnv).map((key) => [key, process.env[key]]),
+    );
+    Object.assign(process.env, expectedEnv);
     process.env["BITBUCKET_API_TOKEN"] = "bitbucket-secret";
     process.env["DB_PASSWORD"] = "database-secret";
-    process.env["OPENAI_API_KEY"] = "codex-credential";
 
     try {
       const promise = createService().executeCodex("/work", "main", "review");
@@ -176,13 +192,19 @@ describe("CodexService", () => {
         string[],
         { env: NodeJS.ProcessEnv },
       ];
+      expect(options.env).toEqual(expect.objectContaining(expectedEnv));
       expect(options.env["BITBUCKET_API_TOKEN"]).toBeUndefined();
       expect(options.env["DB_PASSWORD"]).toBeUndefined();
-      expect(options.env["OPENAI_API_KEY"]).toBe("codex-credential");
     } finally {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
       delete process.env["BITBUCKET_API_TOKEN"];
       delete process.env["DB_PASSWORD"];
-      delete process.env["OPENAI_API_KEY"];
     }
   });
 

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -15,15 +15,24 @@ const MAX_STDERR_BYTES = 64 * 1024;
 const CAPACITY_ERROR_MESSAGE =
   "Selected model is at capacity. Please try a different model.";
 const TIMEOUT_EXIT_CODE = 124;
-const CODEX_ENV_ALLOWLIST = new Set([
-  "HOME",
-  "LANG",
-  "LC_ALL",
-  "OPENAI_API_KEY",
-  "OPENAI_BASE_URL",
-  "PATH",
-  "TMPDIR",
-]);
+const CODEX_ENV_ALLOWLIST: Record<string, true> = {
+  HOME: true,
+  LANG: true,
+  LC_ALL: true,
+  OPENAI_API_KEY: true,
+  OPENAI_BASE_URL: true,
+  PATH: true,
+  TMPDIR: true,
+  CODEX_HOME: true,
+  HTTP_PROXY: true,
+  HTTPS_PROXY: true,
+  NO_PROXY: true,
+  SSL_CERT_FILE: true,
+  SSL_CERT_DIR: true,
+  http_proxy: true,
+  https_proxy: true,
+  no_proxy: true,
+};
 
 interface ISpawnResult {
   readonly code: number;
@@ -78,7 +87,7 @@ export class CodexService {
         continue;
       }
 
-      if (!CODEX_ENV_ALLOWLIST.has(key)) {
+      if (!Object.hasOwn(CODEX_ENV_ALLOWLIST, key)) {
         continue;
       }
 

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -15,7 +15,15 @@ const MAX_STDERR_BYTES = 64 * 1024;
 const CAPACITY_ERROR_MESSAGE =
   "Selected model is at capacity. Please try a different model.";
 const TIMEOUT_EXIT_CODE = 124;
-const CODEX_ENV_DENYLIST = new Set(["CODEX_AUTH_JSON"]);
+const CODEX_ENV_ALLOWLIST = new Set([
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "PATH",
+  "TMPDIR",
+]);
 
 interface ISpawnResult {
   readonly code: number;
@@ -70,11 +78,7 @@ export class CodexService {
         continue;
       }
 
-      if (
-        CODEX_ENV_DENYLIST.has(key) ||
-        value.includes("\n") ||
-        value.includes("\r")
-      ) {
+      if (!CODEX_ENV_ALLOWLIST.has(key)) {
         continue;
       }
 

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -87,7 +87,11 @@ export class CodexService {
         continue;
       }
 
-      if (!Object.hasOwn(CODEX_ENV_ALLOWLIST, key)) {
+      if (
+        !Object.hasOwn(CODEX_ENV_ALLOWLIST, key) ||
+        value.includes("\n") ||
+        value.includes("\r")
+      ) {
         continue;
       }
 


### PR DESCRIPTION
### Motivation
- The Codex child process inherited the full `process.env`, exposing DB, Redis, Bitbucket, webhook and other service secrets to untrusted PR-controlled runs; this created a practical secret-exfiltration path when model output is posted to PRs. 
- The intent is to prevent sensitive worker/deployment environment variables from being visible to the untrusted Codex run while preserving the runtime variables needed for the Codex CLI to authenticate and operate. 
- Assumption: Codex only needs a small set of runtime/auth variables (e.g. `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `PATH`, `HOME`, locale/TMP) and does not require DB/Redis/Bitbucket credentials. 

### Description
- Replace the permissive denylist with an explicit environment allowlist in `src/codex/codex.service.ts` so only a minimal set of safe runtime and Codex-auth variables are passed to the child process. 
- Implement `buildCodexEnv()` to construct the child `env` from the new `CODEX_ENV_ALLOWLIST` rather than inheriting all `process.env`. 
- Update the unit test `src/codex/codex.service.spec.ts` to assert that service secrets (e.g. `DB_PASSWORD`, `BITBUCKET_API_TOKEN`) are not forwarded while Codex credentials (`OPENAI_API_KEY`) remain available. 
- Document the change and completed verification in `.context/TASKS.md` (Task 30 entry). 

### Testing
- Ran `pnpm build` and `pnpm lint` successfully. 
- Ran full test suite with `pnpm test --runInBand` and all tests passed (204 tests). 
- Ran coverage `pnpm test:cov --runInBand` and achieved 86.77% statement coverage. 
- Ran focused unit tests `pnpm test --runInBand src/codex/codex.service.spec.ts` and they passed (20 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79fae1cb1483279aecbe035a1f43fe)