### PR TITLE
build: upgrade codex cli to 0.149.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache git ca-certificates curl tini
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --prod --frozen-lockfile
 # renovate: datasource=npm depName=@openai/codex
-RUN npm install -g @openai/codex@0.144.1
+RUN npm install -g @openai/codex@0.149.1
 
 COPY --from=build /app/dist ./dist
 


### PR DESCRIPTION
Dockerfile의 `@openai/codex` 핀을 0.144.1 → 0.149.1로 올림.

검증: `docker build --platform linux/amd64` 성공, 이미지 내 `codex-cli 0.149.1` 확인.