### PR TITLE
ci: bump docker actions to node24 runtimes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,17 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -41,7 +41,7 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Docker Publish 워크플로의 Node.js 20 deprecation 경고 제거.

- setup-qemu-action v3 → v4
- setup-buildx-action v3 → v4
- login-action v3 → v4
- metadata-action v5 → v6
- build-push-action v6 → v7

각 major의 breaking change는 Node 24 전환과 deprecated 입력/환경변수 제거(`DOCKER_BUILD_NO_SUMMARY`, `DOCKER_BUILD_EXPORT_RETENTION_DAYS` 등)이며, 이 워크플로는 해당 입력을 사용하지 않음.