### PR TITLE
fix: 최초 clone 타임아웃 상향 + producer 큐 재시도 배선

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,8 +1,24 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-08-10
+> 마지막 업데이트: 2026-08-26
 
 ## 진행 중/최근 작업
+
+### Task 31: 최초 clone 타임아웃 + 큐 재시도 미배선 수정
+- **상태**: ✅ 완료
+- **배경**: 운영에서 `todoeng-academy-web` PR #31 리뷰가 정확히 120.005초에 `Git clone failed`로 실패. 인증·인스턴스 병목 아님(같은 순간 API 코멘트 성공, CPU 1.9%). 같은 컨테이너에서 수동 재현 시 28초/29MB 성공 — 최초 pack 생성 대기로 **추정**. 로그는 `failed permanently after 1 attempts`로, 정의된 재시도도 실효 없었음.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| clone 타임아웃 설정화 | ✅ | `ensureBareRepo` 120s 하드코딩 → `workspace.cloneTimeoutMs`(`GIT_CLONE_TIMEOUT_MS`, 기본 600s). 타임아웃 kill 시 git이 부분 디렉토리를 정리해 재시도도 0부터 다시 받는 구조라 넉넉한 값이 필요 |
+| fetchLatest 타임아웃 | ✅ | 60s → 300s 하드코딩 유지. 오래 방치된 repo의 증분 fetch도 같은 서버측 pack 생성 대기를 겪음. clone과 달리 실패해도 bare repo가 남아 재시도가 저렴하므로 env 노출은 생략 |
+| 큐 등록 일원화 | ✅ | `WebhookModule`의 중복 `registerQueue`(defaultJobOptions 없음) 제거 → `QueueModule` import. producer(`webhook.controller.ts`의 `@InjectQueue`)가 옵션 없는 별개 인스턴스를 쓰던 원인 |
+| QUEUE_RETRY_* 실제 배선 | ✅ | `registerQueueAsync` + `ConfigService`로 `attempts`=`queue.retryAttempts`, exponential backoff delay=`queue.retryDelay`. 죽은 설정 2개를 살리는 쪽을 선택. `REVIEW_QUEUE_CONFIG`의 `attempts: 2`/`delay: 10_000`은 producer 경로에 적용된 적이 없어 제거(단일 출처 = env) |
+| 회귀 테스트 | ✅ | `queue.module.spec.ts` 3케이스 — 등록된 큐의 `attempts>1`, env override 반영, producer가 자체 `registerQueue`를 하지 않음. 수정 전 상태 재현 시 RED 확인 |
+| clone 타임아웃 테스트 | ✅ | `workspace.service.spec.ts` clone 호출이 config 값(900s)을 `timeout`으로 받는지 검증 |
+| 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test:cov` 성공 (210 tests, statement 86.82%) |
+| 보안 체크리스트 | ✅ | 시크릿·신규 외부 입력 없음, clone 에러 URL 마스킹 로직 유지 |
+| 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 
 ### Task 30: 리뷰 근거 범위 분리 + 검증 가능성 게이트
 - **상태**: ✅ 완료

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -20,6 +20,7 @@
 | 보안 체크리스트 | ✅ | 시크릿·신규 외부 입력 없음, clone 에러 URL 마스킹 로직 유지 |
 | PR #25 Codex 리뷰 반영 (P1 2건) | ✅ | 재시도를 실제로 켜면서 생긴 노출 2건. ① 게시 전 실패는 마지막 시도에서만 FAILED 기록·실패 코멘트 → 중간 시도의 "❌ 실패" 코멘트와, 백오프 중 `existsByIdempotencyKey`가 FAILED 행을 지우고 재시도 잡을 제거하는 경로를 차단 ② 게시 단계 진입 후 실패는 `UnrecoverableError`로 재시도 차단(리뷰 코멘트 중복 게시 + Codex 재실행 방지). `onFailed` 로그도 재시도/최종 실패를 구분 — BullMQ는 재시도로 이어지는 실패에도 `failed`를 emit한다 |
 | PR #25 Codex 재리뷰 반영 (P1 1건) | ✅ | catch의 `updateStatus(FAILED)`가 던지면 `UnrecoverableError` 분기에 도달하지 못해 게시 이후 실패가 재시도된다(DB 장애면 `markCompleted`와 이 쓰기가 같이 실패하는 상관 케이스). 상태 기록을 try/catch로 감싸 재시도 판단이 DB 성공 여부에 의존하지 않게 했다. 회귀 테스트 1케이스 추가 |
+| PR #25 Codex 3차 리뷰 반영 (P1 1건) | ✅ | `publishStarted`를 `publishResults()` 진입 시점에 세우면 그 안의 `updateStatus(PUBLISHING)` DB 실패까지 재시도 불가로 처리되어 리뷰가 유실된다. 상태 전이를 `process()`로 끌어올려 **Bitbucket 쓰기 직전**에만 플래그를 세운다 — 남은 구간은 파싱·포맷팅(순수 연산)뿐. 회귀 테스트 1케이스 추가 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 
 ### Task 30: 리뷰 근거 범위 분리 + 검증 가능성 게이트

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -21,6 +21,8 @@
 | PR #25 Codex 리뷰 반영 (P1 2건) | ✅ | 재시도를 실제로 켜면서 생긴 노출 2건. ① 게시 전 실패는 마지막 시도에서만 FAILED 기록·실패 코멘트 → 중간 시도의 "❌ 실패" 코멘트와, 백오프 중 `existsByIdempotencyKey`가 FAILED 행을 지우고 재시도 잡을 제거하는 경로를 차단 ② 게시 단계 진입 후 실패는 `UnrecoverableError`로 재시도 차단(리뷰 코멘트 중복 게시 + Codex 재실행 방지). `onFailed` 로그도 재시도/최종 실패를 구분 — BullMQ는 재시도로 이어지는 실패에도 `failed`를 emit한다 |
 | PR #25 Codex 재리뷰 반영 (P1 1건) | ✅ | catch의 `updateStatus(FAILED)`가 던지면 `UnrecoverableError` 분기에 도달하지 못해 게시 이후 실패가 재시도된다(DB 장애면 `markCompleted`와 이 쓰기가 같이 실패하는 상관 케이스). 상태 기록을 try/catch로 감싸 재시도 판단이 DB 성공 여부에 의존하지 않게 했다. 회귀 테스트 1케이스 추가 |
 | PR #25 Codex 3차 리뷰 반영 (P1 1건) | ✅ | `publishStarted`를 `publishResults()` 진입 시점에 세우면 그 안의 `updateStatus(PUBLISHING)` DB 실패까지 재시도 불가로 처리되어 리뷰가 유실된다. 상태 전이를 `process()`로 끌어올려 **Bitbucket 쓰기 직전**에만 플래그를 세운다 — 남은 구간은 파싱·포맷팅(순수 연산)뿐. 회귀 테스트 1케이스 추가 |
+| PR #25 Codex 4차 리뷰 반영 (P1 1건) | ✅ | 백오프 중 새 커밋 리뷰가 `supersedeActivePrReviews`로 이 런을 `SUPERSEDED`로 바꿔도, 재시도가 `prepareWorkspace()`에서 `PREPARING`으로 되살리고 구버전 리뷰를 게시했다. 재시도(`attemptsMade > 0`)일 때만 `findById`로 상태를 확인해 `SUPERSEDED`/행 삭제면 작업 없이 종료. 회귀 테스트 2케이스 |
+| 후속 과제 (B안, 이 PR 범위 밖) | ⚠️ | supersede를 게시 경로 전반에서 존중하는 문제는 이 PR 이전부터 있다 — `idempotencyKey`에 head commit이 들어가므로 새 커밋 웹훅은 실행 중인 이전 잡의 `jobId`를 찾지 못하고(`webhook.controller.ts:149`) 제거하지 못한다. 즉 **실행 중**인 구버전 리뷰는 지금도 끝까지 게시된다. idempotency 모델 손질이 필요해 별도 이슈로 남긴다 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 
 ### Task 30: 리뷰 근거 범위 분리 + 검증 가능성 게이트

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -26,7 +26,7 @@
 | PR #25 Codex 5차 리뷰 반영 (P2 1건) | ✅ | `GIT_CLONE_TIMEOUT_MS`가 `Joi.number()`라 음수·소수를 통과시키고, `execFile`이 git 실행 전에 `ERR_OUT_OF_RANGE`를 던져 모든 clone이 실패한다. `.integer().positive()`로 부팅 시 차단. 0(타임아웃 없음)도 불허 — 멈춘 clone이 워커 슬롯을 영구 점유한다. 회귀 테스트 4케이스 |
 | PR #25 Codex 6차 리뷰 반영 (P2 2건) | ✅ | ① `QUEUE_RETRY_DELAY=-1`이 Joi를 통과하면 BullMQ가 계산된 백오프 `-1`을 "재시도 안 함" 신호로 읽어, 이 PR이 켠 재시도가 조용히 죽는다. 게다가 `process()`의 "시도가 남았으면 보류" 분기는 여전히 참이라 FAILED 기록·실패 코멘트가 생략되고 런이 `preparing`으로 잔류한다. `QUEUE_RETRY_ATTEMPTS`는 0·음수·소수도 통과. → attempts `.integer().positive()`, delay `.integer().min(0)` ② `GIT_CLONE_TIMEOUT_MS` 상한 없음 — 2^31-1 초과는 Node 타이머가 ~1ms로 접어 타임아웃이 되레 짧아진다. `.max(2_147_483_647)` 추가. 회귀 테스트 7케이스 |
 | 미적용 (기존 스키마) | ⚠️ | `CODEX_TIMEOUT_MS`·`WORKSPACE_MAX_CONCURRENT`도 같은 laxity를 갖지만 손대지 않았다. `QUEUE_RETRY_*`는 이 PR이 BullMQ에 실제로 주입하기 시작해 잘못된 값이 곧 기능 상실이라 예외로 조였다(운영값 3/5000은 통과 확인) |
-| 후속 과제 (B안, 이 PR 범위 밖) | ⚠️ | supersede를 게시 경로 전반에서 존중하는 문제는 이 PR 이전부터 있다 — `idempotencyKey`에 head commit이 들어가므로 새 커밋 웹훅은 실행 중인 이전 잡의 `jobId`를 찾지 못하고(`webhook.controller.ts:149`) 제거하지 못한다. 즉 **실행 중**인 구버전 리뷰는 지금도 끝까지 게시된다. idempotency 모델 손질이 필요해 별도 이슈로 남긴다 |
+| 후속 과제 (이 PR 범위 밖) | ⚠️ | 코드로 확인한 뒤 이슈로 분리했다 — #26 supersede/idempotency 모델(실행 중 구버전 게시 + 사전조회 TOCTOU + 워커 SIGKILL 우회), #27 게시 후 상태 기록 실패 시 웹훅 재수신으로 중복 게시(`existsByIdempotencyKey`가 FAILED 행 삭제), #28 Bitbucket 첫 쓰기 429/503에도 남은 재시도 폐기(현재는 안전한 쪽 실패), #29 인라인 코멘트 부분 실패 삼킴, #30 재시도 시 중간 시도의 Codex 토큰·소요시간 통계 누락 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 
 ### Task 30: 리뷰 근거 범위 분리 + 검증 가능성 게이트

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -24,7 +24,8 @@
 | PR #25 Codex 4차 리뷰 반영 (P1 1건) | ✅ | 백오프 중 새 커밋 리뷰가 `supersedeActivePrReviews`로 이 런을 `SUPERSEDED`로 바꿔도, 재시도가 `prepareWorkspace()`에서 `PREPARING`으로 되살리고 구버전 리뷰를 게시했다. 재시도(`attemptsMade > 0`)일 때만 `findById`로 상태를 확인해 `SUPERSEDED`/행 삭제면 작업 없이 종료. 회귀 테스트 2케이스 |
 | codex CLI 독립 리뷰 반영 (P1 1건) | ✅ | 재시도 사전 조회(`findById`)가 `try` 밖에 있어, DB 장애로 조회 자체가 실패하면 마지막 시도에서도 FAILED 기록과 사용자 알림이 모두 생략되고 런이 `preparing`으로 영구 잔류한다. 가드를 `try` 안으로 이동해 기존 최종 실패 경로를 타게 했다. 회귀 테스트 1케이스 |
 | PR #25 Codex 5차 리뷰 반영 (P2 1건) | ✅ | `GIT_CLONE_TIMEOUT_MS`가 `Joi.number()`라 음수·소수를 통과시키고, `execFile`이 git 실행 전에 `ERR_OUT_OF_RANGE`를 던져 모든 clone이 실패한다. `.integer().positive()`로 부팅 시 차단. 0(타임아웃 없음)도 불허 — 멈춘 clone이 워커 슬롯을 영구 점유한다. 회귀 테스트 4케이스 |
-| 미적용 (기존 스키마) | ⚠️ | `CODEX_TIMEOUT_MS`·`QUEUE_RETRY_*`·`WORKSPACE_MAX_CONCURRENT`도 같은 laxity를 갖지만 기존 키라 손대지 않았다. 지금 조이면 이미 그런 값이 들어간 운영 env가 재기동에서 부팅 실패한다 |
+| PR #25 Codex 6차 리뷰 반영 (P2 2건) | ✅ | ① `QUEUE_RETRY_DELAY=-1`이 Joi를 통과하면 BullMQ가 계산된 백오프 `-1`을 "재시도 안 함" 신호로 읽어, 이 PR이 켠 재시도가 조용히 죽는다. 게다가 `process()`의 "시도가 남았으면 보류" 분기는 여전히 참이라 FAILED 기록·실패 코멘트가 생략되고 런이 `preparing`으로 잔류한다. `QUEUE_RETRY_ATTEMPTS`는 0·음수·소수도 통과. → attempts `.integer().positive()`, delay `.integer().min(0)` ② `GIT_CLONE_TIMEOUT_MS` 상한 없음 — 2^31-1 초과는 Node 타이머가 ~1ms로 접어 타임아웃이 되레 짧아진다. `.max(2_147_483_647)` 추가. 회귀 테스트 7케이스 |
+| 미적용 (기존 스키마) | ⚠️ | `CODEX_TIMEOUT_MS`·`WORKSPACE_MAX_CONCURRENT`도 같은 laxity를 갖지만 손대지 않았다. `QUEUE_RETRY_*`는 이 PR이 BullMQ에 실제로 주입하기 시작해 잘못된 값이 곧 기능 상실이라 예외로 조였다(운영값 3/5000은 통과 확인) |
 | 후속 과제 (B안, 이 PR 범위 밖) | ⚠️ | supersede를 게시 경로 전반에서 존중하는 문제는 이 PR 이전부터 있다 — `idempotencyKey`에 head commit이 들어가므로 새 커밋 웹훅은 실행 중인 이전 잡의 `jobId`를 찾지 못하고(`webhook.controller.ts:149`) 제거하지 못한다. 즉 **실행 중**인 구버전 리뷰는 지금도 끝까지 게시된다. idempotency 모델 손질이 필요해 별도 이슈로 남긴다 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -22,6 +22,7 @@
 | PR #25 Codex 재리뷰 반영 (P1 1건) | ✅ | catch의 `updateStatus(FAILED)`가 던지면 `UnrecoverableError` 분기에 도달하지 못해 게시 이후 실패가 재시도된다(DB 장애면 `markCompleted`와 이 쓰기가 같이 실패하는 상관 케이스). 상태 기록을 try/catch로 감싸 재시도 판단이 DB 성공 여부에 의존하지 않게 했다. 회귀 테스트 1케이스 추가 |
 | PR #25 Codex 3차 리뷰 반영 (P1 1건) | ✅ | `publishStarted`를 `publishResults()` 진입 시점에 세우면 그 안의 `updateStatus(PUBLISHING)` DB 실패까지 재시도 불가로 처리되어 리뷰가 유실된다. 상태 전이를 `process()`로 끌어올려 **Bitbucket 쓰기 직전**에만 플래그를 세운다 — 남은 구간은 파싱·포맷팅(순수 연산)뿐. 회귀 테스트 1케이스 추가 |
 | PR #25 Codex 4차 리뷰 반영 (P1 1건) | ✅ | 백오프 중 새 커밋 리뷰가 `supersedeActivePrReviews`로 이 런을 `SUPERSEDED`로 바꿔도, 재시도가 `prepareWorkspace()`에서 `PREPARING`으로 되살리고 구버전 리뷰를 게시했다. 재시도(`attemptsMade > 0`)일 때만 `findById`로 상태를 확인해 `SUPERSEDED`/행 삭제면 작업 없이 종료. 회귀 테스트 2케이스 |
+| codex CLI 독립 리뷰 반영 (P1 1건) | ✅ | 재시도 사전 조회(`findById`)가 `try` 밖에 있어, DB 장애로 조회 자체가 실패하면 마지막 시도에서도 FAILED 기록과 사용자 알림이 모두 생략되고 런이 `preparing`으로 영구 잔류한다. 가드를 `try` 안으로 이동해 기존 최종 실패 경로를 타게 했다. 회귀 테스트 1케이스 |
 | 후속 과제 (B안, 이 PR 범위 밖) | ⚠️ | supersede를 게시 경로 전반에서 존중하는 문제는 이 PR 이전부터 있다 — `idempotencyKey`에 head commit이 들어가므로 새 커밋 웹훅은 실행 중인 이전 잡의 `jobId`를 찾지 못하고(`webhook.controller.ts:149`) 제거하지 못한다. 즉 **실행 중**인 구버전 리뷰는 지금도 끝까지 게시된다. idempotency 모델 손질이 필요해 별도 이슈로 남긴다 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -18,6 +18,7 @@
 | clone 타임아웃 테스트 | ✅ | `workspace.service.spec.ts` clone 호출이 config 값(900s)을 `timeout`으로 받는지 검증 |
 | 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test:cov` 성공 (210 tests, statement 86.82%) |
 | 보안 체크리스트 | ✅ | 시크릿·신규 외부 입력 없음, clone 에러 URL 마스킹 로직 유지 |
+| PR #25 Codex 리뷰 반영 (P1 2건) | ✅ | 재시도를 실제로 켜면서 생긴 노출 2건. ① 게시 전 실패는 마지막 시도에서만 FAILED 기록·실패 코멘트 → 중간 시도의 "❌ 실패" 코멘트와, 백오프 중 `existsByIdempotencyKey`가 FAILED 행을 지우고 재시도 잡을 제거하는 경로를 차단 ② 게시 단계 진입 후 실패는 `UnrecoverableError`로 재시도 차단(리뷰 코멘트 중복 게시 + Codex 재실행 방지). `onFailed` 로그도 재시도/최종 실패를 구분 — BullMQ는 재시도로 이어지는 실패에도 `failed`를 emit한다 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 
 ### Task 30: 리뷰 근거 범위 분리 + 검증 가능성 게이트

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -23,6 +23,8 @@
 | PR #25 Codex 3차 리뷰 반영 (P1 1건) | ✅ | `publishStarted`를 `publishResults()` 진입 시점에 세우면 그 안의 `updateStatus(PUBLISHING)` DB 실패까지 재시도 불가로 처리되어 리뷰가 유실된다. 상태 전이를 `process()`로 끌어올려 **Bitbucket 쓰기 직전**에만 플래그를 세운다 — 남은 구간은 파싱·포맷팅(순수 연산)뿐. 회귀 테스트 1케이스 추가 |
 | PR #25 Codex 4차 리뷰 반영 (P1 1건) | ✅ | 백오프 중 새 커밋 리뷰가 `supersedeActivePrReviews`로 이 런을 `SUPERSEDED`로 바꿔도, 재시도가 `prepareWorkspace()`에서 `PREPARING`으로 되살리고 구버전 리뷰를 게시했다. 재시도(`attemptsMade > 0`)일 때만 `findById`로 상태를 확인해 `SUPERSEDED`/행 삭제면 작업 없이 종료. 회귀 테스트 2케이스 |
 | codex CLI 독립 리뷰 반영 (P1 1건) | ✅ | 재시도 사전 조회(`findById`)가 `try` 밖에 있어, DB 장애로 조회 자체가 실패하면 마지막 시도에서도 FAILED 기록과 사용자 알림이 모두 생략되고 런이 `preparing`으로 영구 잔류한다. 가드를 `try` 안으로 이동해 기존 최종 실패 경로를 타게 했다. 회귀 테스트 1케이스 |
+| PR #25 Codex 5차 리뷰 반영 (P2 1건) | ✅ | `GIT_CLONE_TIMEOUT_MS`가 `Joi.number()`라 음수·소수를 통과시키고, `execFile`이 git 실행 전에 `ERR_OUT_OF_RANGE`를 던져 모든 clone이 실패한다. `.integer().positive()`로 부팅 시 차단. 0(타임아웃 없음)도 불허 — 멈춘 clone이 워커 슬롯을 영구 점유한다. 회귀 테스트 4케이스 |
+| 미적용 (기존 스키마) | ⚠️ | `CODEX_TIMEOUT_MS`·`QUEUE_RETRY_*`·`WORKSPACE_MAX_CONCURRENT`도 같은 laxity를 갖지만 기존 키라 손대지 않았다. 지금 조이면 이미 그런 값이 들어간 운영 env가 재기동에서 부팅 실패한다 |
 | 후속 과제 (B안, 이 PR 범위 밖) | ⚠️ | supersede를 게시 경로 전반에서 존중하는 문제는 이 PR 이전부터 있다 — `idempotencyKey`에 head commit이 들어가므로 새 커밋 웹훅은 실행 중인 이전 잡의 `jobId`를 찾지 못하고(`webhook.controller.ts:149`) 제거하지 못한다. 즉 **실행 중**인 구버전 리뷰는 지금도 끝까지 게시된다. idempotency 모델 손질이 필요해 별도 이슈로 남긴다 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -19,6 +19,7 @@
 | 빌드/린트/테스트 | ✅ | `pnpm build`, `pnpm lint`, `pnpm test:cov` 성공 (210 tests, statement 86.82%) |
 | 보안 체크리스트 | ✅ | 시크릿·신규 외부 입력 없음, clone 에러 URL 마스킹 로직 유지 |
 | PR #25 Codex 리뷰 반영 (P1 2건) | ✅ | 재시도를 실제로 켜면서 생긴 노출 2건. ① 게시 전 실패는 마지막 시도에서만 FAILED 기록·실패 코멘트 → 중간 시도의 "❌ 실패" 코멘트와, 백오프 중 `existsByIdempotencyKey`가 FAILED 행을 지우고 재시도 잡을 제거하는 경로를 차단 ② 게시 단계 진입 후 실패는 `UnrecoverableError`로 재시도 차단(리뷰 코멘트 중복 게시 + Codex 재실행 방지). `onFailed` 로그도 재시도/최종 실패를 구분 — BullMQ는 재시도로 이어지는 실패에도 `failed`를 emit한다 |
+| PR #25 Codex 재리뷰 반영 (P1 1건) | ✅ | catch의 `updateStatus(FAILED)`가 던지면 `UnrecoverableError` 분기에 도달하지 못해 게시 이후 실패가 재시도된다(DB 장애면 `markCompleted`와 이 쓰기가 같이 실패하는 상관 케이스). 상태 기록을 try/catch로 감싸 재시도 판단이 DB 성공 여부에 의존하지 않게 했다. 회귀 테스트 1케이스 추가 |
 | 미포함 | ⚠️ | `GIT_CLONE_TIMEOUT_MS`를 charts/docker-compose에는 추가하지 않음(기본값이 튜닝된 값이고 운영 env는 tools-infra가 관리). `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않음 |
 
 ### Task 30: 리뷰 근거 범위 분리 + 검증 가능성 게이트

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ docker compose up -d
 | `REDIS_QUEUE_PORT` | Redis 포트 | `6379` |
 | `REDIS_QUEUE_PASSWORD` | Redis 비밀번호 | - |
 | `REDIS_QUEUE_DB` | Redis DB 번호 | `0` |
-| `QUEUE_RETRY_ATTEMPTS` | 재시도 횟수 | `3` |
-| `QUEUE_RETRY_DELAY` | 재시도 딜레이 (ms) | `5000` |
+| `QUEUE_RETRY_ATTEMPTS` | 잡 총 시도 횟수 (BullMQ `attempts`) | `3` |
+| `QUEUE_RETRY_DELAY` | 재시도 백오프 기준 딜레이 (ms, exponential) | `5000` |
 
 ### Codex CLI
 
@@ -141,6 +141,7 @@ docker compose up -d
 |---|---|---|
 | `WORKSPACE_BASE_PATH` | 워크스페이스 경로 | `/tmp/code-review-workspaces` |
 | `WORKSPACE_MAX_CONCURRENT` | 최대 동시 워크스페이스 수 | `3` |
+| `GIT_CLONE_TIMEOUT_MS` | 최초 bare clone 타임아웃 (ms) | `600000` |
 
 > [!TIP]
 > 전체 설정은 [`.env.example`](.env.example) 참조.

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -19,6 +19,7 @@ export const DEFAULTS = {
   BITBUCKET_BASE_URL: "https://api.bitbucket.org/2.0",
   WORKSPACE_BASE_PATH: "/tmp/code-review-workspaces",
   WORKSPACE_MAX_CONCURRENT: 3,
+  GIT_CLONE_TIMEOUT_MS: 600_000,
   TRIGGER_MODE: "mention",
   LOG_LEVEL: "info",
 } as const;
@@ -96,6 +97,7 @@ export default (): Record<string, unknown> => ({
   workspace: {
     basePath: process.env["WORKSPACE_BASE_PATH"] || DEFAULTS.WORKSPACE_BASE_PATH,
     maxConcurrent: parseInt(process.env["WORKSPACE_MAX_CONCURRENT"] || String(DEFAULTS.WORKSPACE_MAX_CONCURRENT), 10),
+    cloneTimeoutMs: parseInt(process.env["GIT_CLONE_TIMEOUT_MS"] || String(DEFAULTS.GIT_CLONE_TIMEOUT_MS), 10),
   },
   trigger: {
     mode: process.env["REVIEW_TRIGGER_MODE"] || DEFAULTS.TRIGGER_MODE,

--- a/src/config/validation.spec.ts
+++ b/src/config/validation.spec.ts
@@ -63,6 +63,48 @@ describe("validationSchema", () => {
     expect(value.GIT_CLONE_TIMEOUT_MS).toBe(600_000);
   });
 
+  it("rejects GIT_CLONE_TIMEOUT_MS above the Node timer ceiling", () => {
+    const { error } = validationSchema.validate({
+      ...validEnv,
+      GIT_CLONE_TIMEOUT_MS: 2_147_483_648,
+    });
+
+    // 2^31-1 초과는 Node 타이머가 ~1ms로 접어버려 타임아웃이 되레 짧아진다
+    expect(error?.message).toContain("GIT_CLONE_TIMEOUT_MS");
+  });
+
+  it.each([0, -1, 1.5])("rejects QUEUE_RETRY_ATTEMPTS=%s", (attempts) => {
+    const { error } = validationSchema.validate({
+      ...validEnv,
+      QUEUE_RETRY_ATTEMPTS: attempts,
+    });
+
+    // 0/음수는 재시도를 통째로 없애고, 소수는 BullMQ 비교에서 예측 불가다
+    expect(error?.message).toContain("QUEUE_RETRY_ATTEMPTS");
+  });
+
+  it.each([-1, 1.5])("rejects QUEUE_RETRY_DELAY=%s", (delay) => {
+    const { error } = validationSchema.validate({
+      ...validEnv,
+      QUEUE_RETRY_DELAY: delay,
+    });
+
+    // BullMQ는 계산된 백오프가 음수면 "재시도 안 함" 신호로 읽는다
+    expect(error?.message).toContain("QUEUE_RETRY_DELAY");
+  });
+
+  it("accepts the retry settings used in production", () => {
+    const { error, value } = validationSchema.validate({
+      ...validEnv,
+      QUEUE_RETRY_ATTEMPTS: 3,
+      QUEUE_RETRY_DELAY: 5000,
+    });
+
+    expect(error).toBeUndefined();
+    expect(value.QUEUE_RETRY_ATTEMPTS).toBe(3);
+    expect(value.QUEUE_RETRY_DELAY).toBe(5000);
+  });
+
   it("rejects repo token JSON arrays", () => {
     const { error } = validationSchema.validate({
       ...validEnv,

--- a/src/config/validation.spec.ts
+++ b/src/config/validation.spec.ts
@@ -43,6 +43,26 @@ describe("validationSchema", () => {
     );
   });
 
+  it.each([-1, 0, 1.5])(
+    "rejects GIT_CLONE_TIMEOUT_MS=%s",
+    (timeout) => {
+      const { error } = validationSchema.validate({
+        ...validEnv,
+        GIT_CLONE_TIMEOUT_MS: timeout,
+      });
+
+      // execFile은 음수·소수 timeout에 ERR_OUT_OF_RANGE를 던진다 — 부팅에서 막는다
+      expect(error?.message).toContain("GIT_CLONE_TIMEOUT_MS");
+    },
+  );
+
+  it("defaults GIT_CLONE_TIMEOUT_MS to 600000ms", () => {
+    const { error, value } = validationSchema.validate(validEnv);
+
+    expect(error).toBeUndefined();
+    expect(value.GIT_CLONE_TIMEOUT_MS).toBe(600_000);
+  });
+
   it("rejects repo token JSON arrays", () => {
     const { error } = validationSchema.validate({
       ...validEnv,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -64,6 +64,7 @@ export const validationSchema = Joi.object({
     .custom(jsonObjectValidator("BITBUCKET_REPO_WEBHOOK_SECRETS")),
   WORKSPACE_BASE_PATH: Joi.string().default(DEFAULTS.WORKSPACE_BASE_PATH),
   WORKSPACE_MAX_CONCURRENT: Joi.number().default(DEFAULTS.WORKSPACE_MAX_CONCURRENT),
+  GIT_CLONE_TIMEOUT_MS: Joi.number().default(DEFAULTS.GIT_CLONE_TIMEOUT_MS),
   REVIEW_TRIGGER_MODE: Joi.string()
     .valid("mention", "auto", "both")
     .default(DEFAULTS.TRIGGER_MODE),

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -64,7 +64,12 @@ export const validationSchema = Joi.object({
     .custom(jsonObjectValidator("BITBUCKET_REPO_WEBHOOK_SECRETS")),
   WORKSPACE_BASE_PATH: Joi.string().default(DEFAULTS.WORKSPACE_BASE_PATH),
   WORKSPACE_MAX_CONCURRENT: Joi.number().default(DEFAULTS.WORKSPACE_MAX_CONCURRENT),
-  GIT_CLONE_TIMEOUT_MS: Joi.number().default(DEFAULTS.GIT_CLONE_TIMEOUT_MS),
+  // execFile은 음수·소수 timeout에 ERR_OUT_OF_RANGE를 던진다 — 부팅 시 걸러낸다.
+  // 0(타임아웃 없음)도 허용하지 않는다: 멈춘 clone이 워커 슬롯을 영구 점유한다.
+  GIT_CLONE_TIMEOUT_MS: Joi.number()
+    .integer()
+    .positive()
+    .default(DEFAULTS.GIT_CLONE_TIMEOUT_MS),
   REVIEW_TRIGGER_MODE: Joi.string()
     .valid("mention", "auto", "both")
     .default(DEFAULTS.TRIGGER_MODE),

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -37,8 +37,17 @@ export const validationSchema = Joi.object({
   REDIS_QUEUE_USERNAME: Joi.string().allow("").default(""),
   REDIS_QUEUE_PASSWORD: Joi.string().allow("").required(),
   REDIS_QUEUE_DB: Joi.number().required(),
-  QUEUE_RETRY_ATTEMPTS: Joi.number().default(DEFAULTS.QUEUE_RETRY_ATTEMPTS),
-  QUEUE_RETRY_DELAY: Joi.number().default(DEFAULTS.QUEUE_RETRY_DELAY),
+  // BullMQ attempts/backoff로 그대로 들어간다 (queue.module.ts).
+  // attempts 0·음수는 재시도를 없애고, delay 음수는 계산된 백오프가 -1이 되어
+  // BullMQ가 "재시도 안 함" 신호로 읽는다 — 둘 다 조용히 실패하므로 부팅에서 막는다.
+  QUEUE_RETRY_ATTEMPTS: Joi.number()
+    .integer()
+    .positive()
+    .default(DEFAULTS.QUEUE_RETRY_ATTEMPTS),
+  QUEUE_RETRY_DELAY: Joi.number()
+    .integer()
+    .min(0)
+    .default(DEFAULTS.QUEUE_RETRY_DELAY),
   CODEX_BINARY_PATH: Joi.string().default(DEFAULTS.CODEX_BINARY_PATH),
   CODEX_TIMEOUT_MS: Joi.number().default(DEFAULTS.CODEX_TIMEOUT_MS),
   CODEX_MODEL: Joi.string().default(DEFAULTS.CODEX_MODEL),
@@ -66,9 +75,11 @@ export const validationSchema = Joi.object({
   WORKSPACE_MAX_CONCURRENT: Joi.number().default(DEFAULTS.WORKSPACE_MAX_CONCURRENT),
   // execFile은 음수·소수 timeout에 ERR_OUT_OF_RANGE를 던진다 — 부팅 시 걸러낸다.
   // 0(타임아웃 없음)도 허용하지 않는다: 멈춘 clone이 워커 슬롯을 영구 점유한다.
+  // 2^31-1 초과는 Node 타이머가 ~1ms로 접어 타임아웃이 되레 짧아진다.
   GIT_CLONE_TIMEOUT_MS: Joi.number()
     .integer()
     .positive()
+    .max(2_147_483_647)
     .default(DEFAULTS.GIT_CLONE_TIMEOUT_MS),
   REVIEW_TRIGGER_MODE: Joi.string()
     .valid("mention", "auto", "both")

--- a/src/constants/queue.constants.ts
+++ b/src/constants/queue.constants.ts
@@ -1,14 +1,10 @@
 export const REVIEW_QUEUE_NAME = "review-job" as const;
 export const REVIEW_DLQ_NAME = "review-dlq" as const;
 
+/** attempts/backoff는 QUEUE_RETRY_ATTEMPTS/QUEUE_RETRY_DELAY에서 주입된다 (queue.module.ts) */
 export const REVIEW_QUEUE_CONFIG = {
   defaultJobOptions: {
     removeOnComplete: 100,
     removeOnFail: 500,
-    attempts: 2,
-    backoff: {
-      type: "exponential" as const,
-      delay: 10_000,
-    },
   },
 } as const;

--- a/src/queue/queue.module.spec.ts
+++ b/src/queue/queue.module.spec.ts
@@ -1,0 +1,82 @@
+import "reflect-metadata";
+import { BullModule, getQueueOptionsToken } from "@nestjs/bullmq";
+import { ConfigService } from "@nestjs/config";
+import { DEFAULTS } from "../config/configuration";
+import { REVIEW_QUEUE_NAME } from "../constants/queue.constants";
+import { QueueModule } from "./queue.module";
+import { WebhookModule } from "../webhook/webhook.module";
+
+type ProviderLike = {
+  provide?: unknown;
+  useFactory?: (...args: unknown[]) => unknown;
+};
+type DynamicModuleLike = { module?: unknown; providers?: ProviderLike[] };
+
+const importsOf = (module: unknown): unknown[] =>
+  (Reflect.getMetadata("imports", module as object) as unknown[]) ?? [];
+
+const isBullRegistration = (imported: unknown): boolean =>
+  typeof imported === "object" &&
+  imported !== null &&
+  (imported as DynamicModuleLike).module === BullModule;
+
+const buildConfigService = (values: Record<string, unknown>): ConfigService =>
+  ({
+    get: jest.fn((key: string, defaultValue?: unknown) =>
+      key in values ? values[key] : defaultValue,
+    ),
+  }) as unknown as ConfigService;
+
+/** registerQueueAsync가 감싼 factory는 (depHolder, ...inject) 순서로 호출된다 */
+const resolveQueueOptions = async (
+  values: Record<string, unknown>,
+): Promise<{ defaultJobOptions?: Record<string, unknown> }> => {
+  const registration = importsOf(QueueModule).find(
+    isBullRegistration,
+  ) as DynamicModuleLike;
+  expect(registration).toBeDefined();
+
+  const optionsProvider = (registration.providers ?? []).find(
+    (provider) => provider.provide === getQueueOptionsToken(REVIEW_QUEUE_NAME),
+  );
+  expect(optionsProvider?.useFactory).toBeDefined();
+
+  return (await optionsProvider!.useFactory!(
+    { getDependencyRef: () => ({}) },
+    buildConfigService(values),
+  )) as { defaultJobOptions?: Record<string, unknown> };
+};
+
+describe("QueueModule queue registration", () => {
+  it("registers the review queue with retries enabled", async () => {
+    const options = await resolveQueueOptions({});
+
+    expect(options.defaultJobOptions).toMatchObject({
+      attempts: DEFAULTS.QUEUE_RETRY_ATTEMPTS,
+      backoff: { type: "exponential", delay: DEFAULTS.QUEUE_RETRY_DELAY },
+    });
+    expect(
+      options.defaultJobOptions?.["attempts"] as number,
+    ).toBeGreaterThan(1);
+  });
+
+  it("takes attempts/backoff from QUEUE_RETRY_* config", async () => {
+    const options = await resolveQueueOptions({
+      "queue.retryAttempts": 5,
+      "queue.retryDelay": 1234,
+    });
+
+    expect(options.defaultJobOptions).toMatchObject({
+      attempts: 5,
+      backoff: { type: "exponential", delay: 1234 },
+    });
+  });
+
+  it("keeps the producer module on the same queue instance", () => {
+    const webhookImports = importsOf(WebhookModule);
+
+    expect(webhookImports).toContain(QueueModule);
+    // 자체 registerQueue는 defaultJobOptions 없는 별개 인스턴스를 만든다 — 금지
+    expect(webhookImports.some(isBullRegistration)).toBe(false);
+  });
+});

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -1,9 +1,11 @@
 import { Module } from "@nestjs/common";
 import { BullModule } from "@nestjs/bullmq";
+import { ConfigService } from "@nestjs/config";
 import {
   REVIEW_QUEUE_NAME,
   REVIEW_QUEUE_CONFIG,
 } from "../constants/queue.constants";
+import { DEFAULTS } from "../config/configuration";
 import { ReviewProcessor } from "./review.processor";
 import { ReviewModule } from "../review/review.module";
 import { WorkspaceModule } from "../workspace/workspace.module";
@@ -12,9 +14,27 @@ import { BitbucketModule } from "../bitbucket/bitbucket.module";
 
 @Module({
   imports: [
-    BullModule.registerQueue({
+    // 큐 등록은 이 모듈에서만 한다 — producer(WebhookModule)가 다시 등록하면
+    // defaultJobOptions 없는 별개 인스턴스가 생겨 재시도가 사라진다.
+    BullModule.registerQueueAsync({
       name: REVIEW_QUEUE_NAME,
-      defaultJobOptions: REVIEW_QUEUE_CONFIG.defaultJobOptions,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        defaultJobOptions: {
+          ...REVIEW_QUEUE_CONFIG.defaultJobOptions,
+          attempts: configService.get<number>(
+            "queue.retryAttempts",
+            DEFAULTS.QUEUE_RETRY_ATTEMPTS,
+          ),
+          backoff: {
+            type: "exponential" as const,
+            delay: configService.get<number>(
+              "queue.retryDelay",
+              DEFAULTS.QUEUE_RETRY_DELAY,
+            ),
+          },
+        },
+      }),
     }),
     ReviewModule,
     WorkspaceModule,

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -1173,6 +1173,7 @@ describe("ReviewProcessor error handling", () => {
     existsByIdempotencyKey: jest.fn(),
     createReviewRun: jest.fn(),
     supersedeActivePrReviews: jest.fn(),
+    findById: jest.fn(),
   };
   const mockWorkspaceService = {
     prepareWorktree: jest.fn(),
@@ -1212,6 +1213,10 @@ describe("ReviewProcessor error handling", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockConfigService.get.mockReturnValue("");
+    mockReviewService.findById.mockResolvedValue({
+      id: 1,
+      reviewStatus: "preparing",
+    });
     mockWorkspaceService.createReviewDiff.mockResolvedValue({
       diff: "diff --git a/src/app.ts b/src/app.ts\n+++ b/src/app.ts\n@@ -1,1 +1,1 @@\n+new line",
       excludedChangedFiles: [],
@@ -1404,6 +1409,27 @@ describe("ReviewProcessor error handling", () => {
         errorMessage: expect.stringContaining("db unavailable"),
       }),
     );
+  });
+
+  it.each([
+    { name: "superseded by a newer run", run: { id: 1, reviewStatus: "superseded" } },
+    { name: "deleted", run: null },
+  ])("should skip a retry whose run was $name", async ({ run }) => {
+    mockReviewService.findById.mockResolvedValue(run);
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 1,
+      opts: { attempts: 3 },
+    } as never;
+
+    await expect(processor.process(job)).resolves.toBeUndefined();
+
+    // 구버전 커밋 리뷰가 새 리뷰 뒤에 게시되면 안 된다
+    expect(mockWorkspaceService.prepareWorktree).not.toHaveBeenCalled();
+    expect(mockCodexService.executeCodex).not.toHaveBeenCalled();
+    expect(mockBitbucketService.createComment).not.toHaveBeenCalled();
+    expect(mockReviewService.updateStatus).not.toHaveBeenCalled();
   });
 
   it("should stay retriable when the publishing status update fails", async () => {

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -1406,6 +1406,42 @@ describe("ReviewProcessor error handling", () => {
     );
   });
 
+  it("should stay retriable when the publishing status update fails", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/tmp/worktree",
+      bareRepoPath: "/tmp/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput:
+        '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+      exitCode: 0,
+      durationMs: 10,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+    // Bitbucket 쓰기 전 DB 전이 실패 — 재시도해도 중복 게시 위험이 없다
+    mockReviewService.updateStatus.mockImplementation(
+      (_id: number, status: string) =>
+        status === "publishing"
+          ? Promise.reject(new Error("db unavailable"))
+          : Promise.resolve(undefined),
+    );
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as never;
+
+    const rejection = await processor.process(job).catch((err) => err);
+
+    expect(rejection).not.toBeInstanceOf(UnrecoverableError);
+    expect((rejection as Error).message).toContain("db unavailable");
+    expect(mockBitbucketService.createComment).not.toHaveBeenCalled();
+  });
+
   it("should stay unrecoverable when persisting the failed status also fails", async () => {
     mockWorkspaceService.prepareWorktree.mockResolvedValue({
       worktreePath: "/tmp/worktree",

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -1405,4 +1405,40 @@ describe("ReviewProcessor error handling", () => {
       }),
     );
   });
+
+  it("should stay unrecoverable when persisting the failed status also fails", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/tmp/worktree",
+      bareRepoPath: "/tmp/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput:
+        '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+      exitCode: 0,
+      durationMs: 10,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+    // DB 장애: markCompleted도, 뒤따르는 FAILED 기록도 실패한다
+    mockReviewService.updateStatus.mockImplementation(
+      (_id: number, status: string) =>
+        status === "completed" || status === "failed"
+          ? Promise.reject(new Error("db unavailable"))
+          : Promise.resolve(undefined),
+    );
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as never;
+
+    await expect(processor.process(job)).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+
+    expect(mockBitbucketService.createComment).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -1432,6 +1432,33 @@ describe("ReviewProcessor error handling", () => {
     expect(mockReviewService.updateStatus).not.toHaveBeenCalled();
   });
 
+  it("should report failure when the retry precheck lookup fails on the last attempt", async () => {
+    mockReviewService.findById.mockRejectedValue(new Error("db unavailable"));
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 2,
+      opts: { attempts: 3 },
+    } as never;
+
+    await expect(processor.process(job)).rejects.toThrow("db unavailable");
+
+    // 조회 실패가 최종 실패 보고를 건너뛰면 런이 preparing으로 영구 잔류한다
+    expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+      1,
+      "failed",
+      expect.objectContaining({
+        errorMessage: expect.stringContaining("db unavailable"),
+      }),
+    );
+    expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining("Code Review 실패"),
+      }),
+    );
+  });
+
   it("should stay retriable when the publishing status update fails", async () => {
     mockWorkspaceService.prepareWorktree.mockResolvedValue({
       worktreePath: "/tmp/worktree",

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -14,6 +14,7 @@ import type { ICodexReviewResult } from "../codex/interfaces/codex.interfaces";
 import { TriggerType } from "../entities/review-run.entity";
 import { IReviewJobData } from "./interfaces/queue.interfaces";
 import { rm, writeFile } from "node:fs/promises";
+import { UnrecoverableError } from "bullmq";
 
 jest.mock("@lib/logger", () => ({
   ServiceLogger: jest.fn().mockImplementation(() => ({
@@ -1307,6 +1308,100 @@ describe("ReviewProcessor error handling", () => {
         body: expect.stringContaining(
           "Selected model is at capacity. Please try a different model.",
         ),
+      }),
+    );
+  });
+
+  it("should defer failure reporting while retries remain", async () => {
+    mockWorkspaceService.prepareWorktree.mockRejectedValue(
+      new Error("Git clone failed"),
+    );
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as never;
+
+    await expect(processor.process(job)).rejects.toThrow("Git clone failed");
+
+    expect(mockReviewService.updateStatus).not.toHaveBeenCalledWith(
+      1,
+      "failed",
+      expect.anything(),
+    );
+    expect(mockBitbucketService.replyToComment).not.toHaveBeenCalled();
+    expect(mockBitbucketService.createComment).not.toHaveBeenCalled();
+  });
+
+  it("should report failure on the last attempt", async () => {
+    mockWorkspaceService.prepareWorktree.mockRejectedValue(
+      new Error("Git clone failed"),
+    );
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 2,
+      opts: { attempts: 3 },
+    } as never;
+
+    await expect(processor.process(job)).rejects.toThrow("Git clone failed");
+
+    expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+      1,
+      "failed",
+      expect.objectContaining({
+        errorMessage: expect.stringContaining("Git clone failed"),
+      }),
+    );
+    expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining("Code Review 실패"),
+      }),
+    );
+  });
+
+  it("should not retry after review results were published", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/tmp/worktree",
+      bareRepoPath: "/tmp/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput:
+        '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+      exitCode: 0,
+      durationMs: 10,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+    mockReviewService.updateStatus.mockImplementation(
+      (_id: number, status: string) =>
+        status === "completed"
+          ? Promise.reject(new Error("db unavailable"))
+          : Promise.resolve(undefined),
+    );
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as never;
+
+    // 재시도하면 summary/inline 코멘트가 중복 게시된다 → UnrecoverableError로 차단
+    await expect(processor.process(job)).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+
+    expect(mockBitbucketService.createComment).toHaveBeenCalledTimes(1);
+    expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+      1,
+      "failed",
+      expect.objectContaining({
+        errorMessage: expect.stringContaining("db unavailable"),
       }),
     );
   });

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -1,5 +1,5 @@
 import { Processor, WorkerHost, OnWorkerEvent } from "@nestjs/bullmq";
-import { Job } from "bullmq";
+import { Job, UnrecoverableError } from "bullmq";
 import { ConfigService } from "@nestjs/config";
 import { ServiceLogger } from "@lib/logger";
 import { REVIEW_QUEUE_NAME } from "../constants/queue.constants";
@@ -47,6 +47,7 @@ export class ReviewProcessor extends WorkerHost {
     let bareRepoPath: string | undefined;
     let codexResult: ICodexReviewResult | undefined;
     let reviewDiff = "";
+    let publishStarted = false;
 
     try {
       // Step 1: Prepare workspace
@@ -70,6 +71,7 @@ export class ReviewProcessor extends WorkerHost {
       );
 
       // Step 3: Publish results to Bitbucket
+      publishStarted = true;
       const commentId = await this.publishResults(data, codexResult, reviewDiff);
 
       // Step 4: Mark completed
@@ -85,6 +87,13 @@ export class ReviewProcessor extends WorkerHost {
         codexResult ||
         (err as Error & { codexResult?: ICodexReviewResult }).codexResult;
       this.logger.error(`Review failed: ${error.message}`);
+
+      // 게시 전 실패이고 시도가 남았으면 FAILED 기록·실패 코멘트를 보류한다.
+      // 지금 FAILED로 적으면 ① 사용자에게 실패 코멘트가 먼저 나가고 뒤늦게 리뷰가 붙는다
+      // ② 백오프 중 같은 웹훅이 FAILED 레코드를 지우고 재시도 잡을 제거해버린다.
+      if (!publishStarted && job.attemptsMade + 1 < (job.opts?.attempts ?? 1)) {
+        throw err;
+      }
 
       await this.reviewService.updateStatus(
         data.reviewRunId,
@@ -132,6 +141,11 @@ export class ReviewProcessor extends WorkerHost {
           });
       }
 
+      // 게시 단계에 진입한 뒤 실패했으면 재시도하면 리뷰 코멘트가 중복 게시되고
+      // Codex도 다시 돌아간다. 재시도 없이 여기서 끊는다.
+      if (publishStarted) {
+        throw new UnrecoverableError(error.message);
+      }
       throw err; // Re-throw to let BullMQ handle retry
     } finally {
       // Cleanup worktree
@@ -145,10 +159,16 @@ export class ReviewProcessor extends WorkerHost {
     }
   }
 
+  // BullMQ는 재시도로 이어지는 실패에도 "failed"를 emit한다 — 최종 실패와 구분해서 남긴다.
   @OnWorkerEvent("failed")
   onFailed(job: Job<IReviewJobData>, error: Error): void {
+    const attempts = job.opts?.attempts ?? 1;
+    const willRetry =
+      job.attemptsMade < attempts && error.name !== "UnrecoverableError";
     this.logger.error(
-      `Job ${job.id} failed permanently after ${job.attemptsMade} attempts: ${error.message}`,
+      willRetry
+        ? `Job ${job.id} failed attempt ${job.attemptsMade}/${attempts}, retrying: ${error.message}`
+        : `Job ${job.id} failed permanently after ${job.attemptsMade} attempts: ${error.message}`,
     );
   }
 

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -43,18 +43,6 @@ export class ReviewProcessor extends WorkerHost {
     const processStartTime = Date.now();
     this.logger.log(`Processing review job: ${data.idempotencyKey}`);
 
-    // 백오프 대기 중 새 커밋 리뷰가 이 런을 대체했으면 구버전 리뷰를 게시하지 않는다.
-    // prepareWorkspace()가 SUPERSEDED를 PREPARING으로 되돌리기 전에 확인해야 한다.
-    if (job.attemptsMade > 0) {
-      const run = await this.reviewService.findById(data.reviewRunId);
-      if (!run || run.reviewStatus === ReviewRunStatus.SUPERSEDED) {
-        this.logger.log(
-          `Skipping retry for inactive review run ${data.reviewRunId}: ${data.idempotencyKey}`,
-        );
-        return;
-      }
-    }
-
     let worktreePath: string | undefined;
     let bareRepoPath: string | undefined;
     let codexResult: ICodexReviewResult | undefined;
@@ -62,6 +50,19 @@ export class ReviewProcessor extends WorkerHost {
     let publishStarted = false;
 
     try {
+      // 백오프 대기 중 새 커밋 리뷰가 이 런을 대체했으면 구버전 리뷰를 게시하지 않는다.
+      // prepareWorkspace()가 SUPERSEDED를 PREPARING으로 되돌리기 전에 확인해야 한다.
+      // 조회 자체가 실패하면(DB 장애) 아래 catch가 재시도/최종 보고를 판단한다.
+      if (job.attemptsMade > 0) {
+        const run = await this.reviewService.findById(data.reviewRunId);
+        if (!run || run.reviewStatus === ReviewRunStatus.SUPERSEDED) {
+          this.logger.log(
+            `Skipping retry for inactive review run ${data.reviewRunId}: ${data.idempotencyKey}`,
+          );
+          return;
+        }
+      }
+
       // Step 1: Prepare workspace
       const worktreeInfo = await this.prepareWorkspace(data);
       worktreePath = worktreeInfo.worktreePath;

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -71,6 +71,11 @@ export class ReviewProcessor extends WorkerHost {
       );
 
       // Step 3: Publish results to Bitbucket
+      // 상태 전이(DB)까지는 재시도해도 안전하다 — Bitbucket 쓰기 직전에만 플래그를 세운다.
+      await this.reviewService.updateStatus(
+        data.reviewRunId,
+        ReviewRunStatus.PUBLISHING,
+      );
       publishStarted = true;
       const commentId = await this.publishResults(data, codexResult, reviewDiff);
 
@@ -272,11 +277,6 @@ export class ReviewProcessor extends WorkerHost {
     codexResult: ICodexReviewResult,
     reviewDiff: string,
   ): Promise<number | undefined> {
-    await this.reviewService.updateStatus(
-      data.reviewRunId,
-      ReviewRunStatus.PUBLISHING,
-    );
-
     const unified = parseUnifiedReviewJson(codexResult.rawOutput, (msg) =>
       this.logger.error(msg),
     );

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -43,6 +43,18 @@ export class ReviewProcessor extends WorkerHost {
     const processStartTime = Date.now();
     this.logger.log(`Processing review job: ${data.idempotencyKey}`);
 
+    // 백오프 대기 중 새 커밋 리뷰가 이 런을 대체했으면 구버전 리뷰를 게시하지 않는다.
+    // prepareWorkspace()가 SUPERSEDED를 PREPARING으로 되돌리기 전에 확인해야 한다.
+    if (job.attemptsMade > 0) {
+      const run = await this.reviewService.findById(data.reviewRunId);
+      if (!run || run.reviewStatus === ReviewRunStatus.SUPERSEDED) {
+        this.logger.log(
+          `Skipping retry for inactive review run ${data.reviewRunId}: ${data.idempotencyKey}`,
+        );
+        return;
+      }
+    }
+
     let worktreePath: string | undefined;
     let bareRepoPath: string | undefined;
     let codexResult: ICodexReviewResult | undefined;

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -95,20 +95,27 @@ export class ReviewProcessor extends WorkerHost {
         throw err;
       }
 
-      await this.reviewService.updateStatus(
-        data.reviewRunId,
-        ReviewRunStatus.FAILED,
-        {
-          reviewOutput: failedCodexResult?.rawOutput,
-          durationMs: failedCodexResult?.durationMs,
-          totalDurationMs: Date.now() - processStartTime,
-          inputTokens: failedCodexResult?.inputTokens ?? undefined,
-          cachedInputTokens:
-            failedCodexResult?.cachedInputTokens ?? undefined,
-          outputTokens: failedCodexResult?.outputTokens ?? undefined,
-          errorMessage: error.message.substring(0, 2000),
-        },
-      );
+      // 상태 기록 실패가 재시도 여부를 뒤집으면 안 된다 — 던지면 아래 UnrecoverableError
+      // 분기에 도달하지 못해 게시 이후 실패가 재시도되고 리뷰가 중복 게시된다.
+      try {
+        await this.reviewService.updateStatus(
+          data.reviewRunId,
+          ReviewRunStatus.FAILED,
+          {
+            reviewOutput: failedCodexResult?.rawOutput,
+            durationMs: failedCodexResult?.durationMs,
+            totalDurationMs: Date.now() - processStartTime,
+            inputTokens: failedCodexResult?.inputTokens ?? undefined,
+            cachedInputTokens: failedCodexResult?.cachedInputTokens ?? undefined,
+            outputTokens: failedCodexResult?.outputTokens ?? undefined,
+            errorMessage: error.message.substring(0, 2000),
+          },
+        );
+      } catch (statusErr) {
+        this.logger.error(
+          `Failed to persist FAILED status: ${(statusErr as Error).message}`,
+        );
+      }
 
       // Notify user about the failure
       const errorBody = `❌ Code Review 실패\n\n\`\`\`\n${error.message.substring(0, 500)}\n\`\`\``;

--- a/src/webhook/webhook.module.ts
+++ b/src/webhook/webhook.module.ts
@@ -1,18 +1,14 @@
 import { Module } from "@nestjs/common";
-import { BullModule } from "@nestjs/bullmq";
-import { REVIEW_QUEUE_NAME } from "../constants/queue.constants";
 import { WebhookController } from "./webhook.controller";
 import { WebhookGuard } from "./webhook.guard";
 import { TriggerService } from "./trigger.service";
+import { QueueModule } from "../queue/queue.module";
 import { ReviewModule } from "../review/review.module";
 import { BitbucketModule } from "../bitbucket/bitbucket.module";
 
 @Module({
-  imports: [
-    BullModule.registerQueue({ name: REVIEW_QUEUE_NAME }),
-    ReviewModule,
-    BitbucketModule,
-  ],
+  // 큐는 QueueModule이 등록한 인스턴스를 재사용한다 (defaultJobOptions 유지)
+  imports: [QueueModule, ReviewModule, BitbucketModule],
   controllers: [WebhookController],
   providers: [WebhookGuard, TriggerService],
 })

--- a/src/workspace/workspace.service.spec.ts
+++ b/src/workspace/workspace.service.spec.ts
@@ -53,6 +53,7 @@ describe("WorkspaceService", () => {
     basePath = await mkdtemp(join(tmpdir(), "workspace-service-spec-"));
     configValues = {
       "workspace.basePath": basePath,
+      "workspace.cloneTimeoutMs": 900_000,
       "bitbucket.repoTokens": {},
       "bitbucket.apiToken": "",
       "bitbucket.username": "",
@@ -93,6 +94,7 @@ describe("WorkspaceService", () => {
         join(basePath, "repos", "repoa.git"),
       ],
       expect.objectContaining({
+        timeout: 900_000,
         env: expect.objectContaining({
           GIT_TERMINAL_PROMPT: "0",
         }),

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -30,11 +30,16 @@ const includePathspecs = REVIEW_DIFF_EXCLUDED_PATHS.map(
 export class WorkspaceService {
   private readonly logger = new ServiceLogger(WorkspaceService.name);
   private readonly basePath: string;
+  private readonly cloneTimeoutMs: number;
 
   constructor(private readonly configService: ConfigService) {
     this.basePath = this.configService.get<string>(
       "workspace.basePath",
       "/tmp/code-review-workspaces",
+    );
+    this.cloneTimeoutMs = this.configService.get<number>(
+      "workspace.cloneTimeoutMs",
+      600_000,
     );
   }
 
@@ -222,11 +227,13 @@ export class WorkspaceService {
     this.logger.log(`Cloning bare repo: ${cloneUrl}`);
 
     try {
+      // 최초 clone은 서버측 pack 생성 대기까지 포함해 수 분이 걸릴 수 있고,
+      // 타임아웃으로 죽으면 부분 디렉토리가 정리되어 재시도도 0부터 다시 받는다.
       await execFileAsync(
         "git",
         ["clone", "--bare", cloneUrl, bareRepoPath],
         {
-          timeout: 120_000,
+          timeout: this.cloneTimeoutMs,
           env: { ...process.env, ...gitAuthEnv },
         },
       );
@@ -248,7 +255,8 @@ export class WorkspaceService {
       ["fetch", "origin", "+refs/heads/*:refs/heads/*", "--prune"],
       {
         cwd: bareRepoPath,
-        timeout: 60_000,
+        // 오래 방치된 repo의 증분 fetch도 같은 서버측 pack 생성 대기를 겪는다
+        timeout: 300_000,
         env: { ...process.env, ...gitAuthEnv },
       },
     );


### PR DESCRIPTION
## 배경

운영 인스턴스에서 발생한 리뷰 실패 2건의 원인을 앱 코드에서 확정했다.

## 원인 1 — 최초 bare clone 타임아웃(120s)이 너무 짧다

인증 문제나 인스턴스 병목이 아니다. 같은 순간 Bitbucket API 코멘트 작성은 성공했고, CPUUtilization 1.9% / CPUCreditBalance 만점 / 디스크 27%였다. 같은 컨테이너·같은 토큰으로 재현하면 28초 / 29MB로 성공한다. 느렸던 이유는 Bitbucket 서버측 최초 pack 생성 대기로 **추정**(확인 불가).

타임아웃 kill 시 git이 부분 디렉토리를 정리하므로 재시도해도 매번 0부터 다시 받는다 → 큰 repo의 첫 리뷰는 구조적으로 실패한다.

- clone 타임아웃 120s 하드코딩 → `GIT_CLONE_TIMEOUT_MS` (기본 **600s**)
- fetch 타임아웃 60s → 300s (하드코딩 유지). 증분 fetch도 같은 서버측 pack 대기를 겪지만, 실패해도 bare repo가 남아 재시도가 저렴하므로 env로 노출하지 않았다.

## 원인 2 — 재시도가 실제로 동작하지 않았다

`WebhookModule`이 같은 큐를 `defaultJobOptions` 없이 다시 register해서, 잡을 넣는 producer(`webhook.controller.ts`의 `@InjectQueue`)가 옵션 없는 별개 인스턴스를 잡고 있었다. 큐 등록을 `QueueModule` 한 곳으로 모으고, 파싱만 되고 아무 데도 전달되지 않던 `QUEUE_RETRY_ATTEMPTS`/`QUEUE_RETRY_DELAY`를 실제로 BullMQ `attempts`/`backoff`에 배선했다(죽은 설정 제거 대신 배선 선택).

### 운영 반영 시 달라지는 동작

1. 시도 횟수는 "2회 → 3회"가 **아니다**. producer 경로에는 `defaultJobOptions`가 아예 없었으므로 **1회(재시도 없음) → 3회**(운영 `.env` `QUEUE_RETRY_ATTEMPTS=3`).
2. 백오프 기준 간격은 삭제된 상수 `delay: 10_000` 대신 `QUEUE_RETRY_DELAY=5000`이 쓰여 **10s → 5s**로 짧아진다. 값이 env로 옮겨간 결과이며, clone 실패 재시도에는 5s로 충분하다고 판단해 그대로 둔다.
3. producer 잡에 `removeOnComplete: 100` / `removeOnFail: 500`이 이제 적용된다. 그 전에 쌓인 완료 잡은 Redis에 남아 있을 수 있다.

## 검증

- `src/queue/queue.module.spec.ts` 신규 3케이스 — 등록된 큐의 `attempts > 1`, `QUEUE_RETRY_*` override 반영, producer 모듈이 자체 `registerQueue`를 하지 않음. `WebhookModule`에 `registerQueue`를 되살리면 즉시 RED (확인 완료).
- `workspace.service.spec.ts` — clone 호출이 config 타임아웃을 받는지 검증.
- 런타임 스모크(일회성, 커밋 제외): `QUEUE_RETRY_ATTEMPTS=4` → 실제 Queue 인스턴스 `{"removeOnComplete":100,"removeOnFail":500,"attempts":4,"backoff":{"type":"exponential","delay":5000}}`.
- `pnpm build` / `pnpm lint` / `pnpm test:cov` — **210 passed**, statement **86.82%** (기준 80%).

## 배포 메모

- 새 env 키 **`GIT_CLONE_TIMEOUT_MS`** (기본 `600000`). 미설정이어도 600s가 적용되므로 오버라이드가 필요할 때만 주입하면 된다.
- 앱 코드 변경이므로 **이미지 재빌드·재배포 필요** (`ghcr.io/azyu/bitbucket-codex-code-review`).
- charts/docker-compose에는 새 키를 추가하지 않았다(기본값이 곧 튜닝값, 운영 env는 tools-infra가 관리).
- `REVIEW_DLQ_NAME`은 기존 미사용 상수로 손대지 않았다.
