### PR TITLE
fix(review): prevent duplicate published runs

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,8 +1,24 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-08-26
+> 마지막 업데이트: 2026-08-31
 
 ## 진행 중/최근 작업
+
+### Task 32: 게시 후 상태 기록 실패 중복 리뷰 차단
+- **상태**: ✅ 완료
+- **배경**: GitHub 이슈 #27. Bitbucket 요약 댓글 게시 후 `markCompleted()`가 실패하면 런이 `FAILED`가 되고, 같은 웹훅 재수신 시 기존 행을 삭제해 Codex와 리뷰 댓글을 중복 실행·게시하던 경로.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 게시 증거 조기 저장 | ✅ | JSON summary/raw fallback의 첫 일반 댓글 ID를 인라인 게시·완료 처리 전에 `resultCommentId`로 저장. 상태를 바꾸지 않는 전용 update라 supersede 상태를 되살리지 않음 |
+| 멱등성 경계 수정 | ✅ | `FAILED + resultCommentId 없음`만 삭제해 재시도하고, 게시 흔적이 있는 FAILED 및 모든 PUBLISHING 행은 중복 요청으로 차단 |
+| 연속 DB 실패 방어 | ✅ | ID 저장 전에 process-local ID를 보존하고 catch의 FAILED metadata에 포함. ID 저장과 FAILED 저장이 모두 실패하면 PUBLISHING이 남아 webhook 재수신을 차단 |
+| 회귀 테스트 | ✅ | FAILED/null·FAILED/ID·PUBLISHING/null 판정, ID-only update await/rejection, JSON/raw 저장 순서, 완료 실패, ID/FAILED 연속 실패 경로 검증 |
+| 적대적 리뷰 | ✅ | correctness/security-operations/contracts 3축, 보완 후 2회 재검토. 최종 blocking finding 없음 |
+| 빌드/린트/테스트 | ✅ | `pnpm lint`, `pnpm build`, `pnpm test --runInBand` 성공 (238 tests), `pnpm test:cov --runInBand` statement 88.01% |
+| 보안 체크리스트 | ✅ | 신규 외부 입력·시크릿·에러 노출·스키마 변경 없음. 내부 result comment ID와 상태만 조회·갱신 |
+| 범위 밖 | ⚠️ | #26 stalled redelivery/supersede TOCTOU, #28 첫 쓰기 429/503, Bitbucket ambiguous response success는 별도 이슈 범위 유지 |
+
 
 ### Task 31: 최초 clone 타임아웃 + 큐 재시도 미배선 수정
 - **상태**: ✅ 완료

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -15,6 +15,7 @@
 | 연속 DB 실패 방어 | ✅ | ID 저장 전에 process-local ID를 보존하고 catch의 FAILED metadata에 포함. ID 저장과 FAILED 저장이 모두 실패하면 PUBLISHING이 남아 webhook 재수신을 차단 |
 | 회귀 테스트 | ✅ | FAILED/null·FAILED/ID·PUBLISHING/null 판정, ID-only update await/rejection, JSON/raw 저장 순서, 완료 실패, ID/FAILED 연속 실패 경로 검증 |
 | 적대적 리뷰 | ✅ | correctness/security-operations/contracts 3축, 보완 후 2회 재검토. 최종 blocking finding 없음 |
+| PR #31 P1 보완 | ✅ | `updateResultCommentId` 일시 실패가 인라인 게시·완료 처리를 중단하지 않도록 콜백에서 격리하고 회귀 테스트 추가 |
 | 빌드/린트/테스트 | ✅ | `pnpm lint`, `pnpm build`, `pnpm test --runInBand` 성공 (238 tests), `pnpm test:cov --runInBand` statement 88.01% |
 | 보안 체크리스트 | ✅ | 신규 외부 입력·시크릿·에러 노출·스키마 변경 없음. 내부 result comment ID와 상태만 조회·갱신 |
 | 범위 밖 | ⚠️ | #26 stalled redelivery/supersede TOCTOU, #28 첫 쓰기 429/503, Bitbucket ambiguous response success는 별도 이슈 범위 유지 |

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -699,6 +699,7 @@ describe("review.formatter", () => {
 describe("ReviewProcessor publish results", () => {
   const mockReviewService = {
     updateStatus: jest.fn(),
+    updateResultCommentId: jest.fn(),
     existsByIdempotencyKey: jest.fn(),
     createReviewRun: jest.fn(),
     supersedeActivePrReviews: jest.fn(),
@@ -990,18 +991,25 @@ describe("ReviewProcessor publish results", () => {
             confidence: number;
             findings: ReadonlyArray<IReviewItem>;
           },
+          reviewDiff: string,
+          onResultCommentPublished: (commentId: number) => Promise<void>,
         ) => Promise<number | undefined>;
       }
-    ).publishUnifiedResults(baseJobData, {
-      summary: [
-        "1) 변경 개요 - learning-trace와 bff-rtc에서 사용하지 않거나 불필요해진 데이터베이스 설정 코드를 정리했습니다.",
-        "2) 주요 변경사항 - apps/learning-trace에서 DB 설정 제거 - apps/bff-rtc에서 미사용 DB 설정 제거",
-        "3) 영향 범위 - 환경변수 관리 혼란이 줄어듭니다.",
-      ].join(" "),
-      verdict: "approve",
-      confidence: 88,
-      findings: [],
-    });
+    ).publishUnifiedResults(
+      baseJobData,
+      {
+        summary: [
+          "1) 변경 개요 - learning-trace와 bff-rtc에서 사용하지 않거나 불필요해진 데이터베이스 설정 코드를 정리했습니다.",
+          "2) 주요 변경사항 - apps/learning-trace에서 DB 설정 제거 - apps/bff-rtc에서 미사용 DB 설정 제거",
+          "3) 영향 범위 - 환경변수 관리 혼란이 줄어듭니다.",
+        ].join(" "),
+        verdict: "approve",
+        confidence: 88,
+        findings: [],
+      },
+      "",
+      async () => undefined,
+    );
 
     expect(mockBitbucketService.createComment).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1107,6 +1115,7 @@ describe("ReviewProcessor publish results", () => {
             findings: ReadonlyArray<IReviewItem>;
           },
           reviewDiff: string,
+          onResultCommentPublished: (commentId: number) => Promise<void>,
         ) => Promise<number | undefined>;
       }
     ).publishUnifiedResults(
@@ -1140,6 +1149,7 @@ describe("ReviewProcessor publish results", () => {
         "@@ -10,0 +12,1 @@",
         "+  { url: '/specs/sso-agent', name: 'SSO AGENT API' },",
       ].join("\n"),
+      async () => undefined,
     );
 
     expect(mockBitbucketService.createInlineComment).toHaveBeenCalledTimes(1);
@@ -1165,11 +1175,131 @@ describe("ReviewProcessor publish results", () => {
       }),
     );
   });
+
+  it("persists the JSON summary comment ID before posting inline comments", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/worktree",
+      bareRepoPath: "/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput: JSON.stringify({
+        summary: "ok",
+        verdict: "comment",
+        confidence: 90,
+        findings: [
+          {
+            title: "Finding",
+            path: "src/app.ts",
+            lineRange: { start: 1, end: 1 },
+            severity: "recommended",
+            description: "description",
+            reason: "reason",
+          },
+        ],
+      }),
+      exitCode: 0,
+      durationMs: 10,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+
+    let releasePersistence: (() => void) | undefined;
+    let signalPersistenceStarted: (() => void) | undefined;
+    const persistenceBlocked = new Promise<void>((resolve) => {
+      releasePersistence = resolve;
+    });
+    const persistenceStarted = new Promise<void>((resolve) => {
+      signalPersistenceStarted = resolve;
+    });
+    mockReviewService.updateResultCommentId.mockImplementationOnce(async () => {
+      signalPersistenceStarted?.();
+      await persistenceBlocked;
+    });
+
+    const processing = processor.process({ data: baseJobData } as never);
+    await persistenceStarted;
+
+    expect(mockBitbucketService.createComment).toHaveBeenCalledTimes(1);
+    expect(mockBitbucketService.createInlineComment).not.toHaveBeenCalled();
+
+    releasePersistence?.();
+    await processing;
+
+    expect(mockReviewService.updateResultCommentId).toHaveBeenCalledWith(1, 100);
+    const commentOrder =
+      mockBitbucketService.createComment.mock.invocationCallOrder[0];
+    const persistOrder =
+      mockReviewService.updateResultCommentId.mock.invocationCallOrder[0];
+    const inlineOrder =
+      mockBitbucketService.createInlineComment.mock.invocationCallOrder[0];
+    expect(commentOrder).toBeLessThan(persistOrder);
+    expect(persistOrder).toBeLessThan(inlineOrder);
+  });
+
+  it("persists the raw fallback comment ID before marking the run completed", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/worktree",
+      bareRepoPath: "/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput: "not JSON",
+      exitCode: 0,
+      durationMs: 10,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+
+    let releasePersistence: (() => void) | undefined;
+    let signalPersistenceStarted: (() => void) | undefined;
+    const persistenceBlocked = new Promise<void>((resolve) => {
+      releasePersistence = resolve;
+    });
+    const persistenceStarted = new Promise<void>((resolve) => {
+      signalPersistenceStarted = resolve;
+    });
+    mockReviewService.updateResultCommentId.mockImplementationOnce(async () => {
+      signalPersistenceStarted?.();
+      await persistenceBlocked;
+    });
+
+    const processing = processor.process({ data: baseJobData } as never);
+    await persistenceStarted;
+
+    expect(mockReviewService.updateStatus).not.toHaveBeenCalledWith(
+      1,
+      "completed",
+      expect.anything(),
+    );
+
+    releasePersistence?.();
+    await processing;
+
+    expect(mockReviewService.updateResultCommentId).toHaveBeenCalledWith(1, 100);
+    const persistOrder =
+      mockReviewService.updateResultCommentId.mock.invocationCallOrder[0];
+    const completedCallIndex =
+      mockReviewService.updateStatus.mock.calls.findIndex(
+        ([, status]) => status === "completed",
+      );
+    const completedOrder =
+      mockReviewService.updateStatus.mock.invocationCallOrder[
+        completedCallIndex
+      ];
+    expect(
+      mockBitbucketService.createComment.mock.invocationCallOrder[0],
+    ).toBeLessThan(persistOrder);
+    expect(persistOrder).toBeLessThan(completedOrder);
+  });
 });
 
 describe("ReviewProcessor error handling", () => {
   const mockReviewService = {
     updateStatus: jest.fn(),
+    updateResultCommentId: jest.fn(),
     existsByIdempotencyKey: jest.fn(),
     createReviewRun: jest.fn(),
     supersedeActivePrReviews: jest.fn(),
@@ -1368,7 +1498,7 @@ describe("ReviewProcessor error handling", () => {
     );
   });
 
-  it("should not retry after review results were published", async () => {
+  it("preserves the comment ID in FAILED metadata when markCompleted fails", async () => {
     mockWorkspaceService.prepareWorktree.mockResolvedValue({
       worktreePath: "/tmp/worktree",
       bareRepoPath: "/tmp/bare",
@@ -1406,9 +1536,11 @@ describe("ReviewProcessor error handling", () => {
       1,
       "failed",
       expect.objectContaining({
+        resultCommentId: 100,
         errorMessage: expect.stringContaining("db unavailable"),
       }),
     );
+    expect(mockReviewService.updateResultCommentId).toHaveBeenCalledWith(1, 100);
   });
 
   it.each([
@@ -1529,5 +1661,105 @@ describe("ReviewProcessor error handling", () => {
     );
 
     expect(mockBitbucketService.createComment).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the process-local comment ID when its early persistence fails", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/tmp/worktree",
+      bareRepoPath: "/tmp/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput:
+        '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+      exitCode: 0,
+      durationMs: 10,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+    mockReviewService.updateStatus.mockResolvedValue(undefined);
+    mockReviewService.updateResultCommentId.mockRejectedValue(
+      new Error("comment ID persistence unavailable"),
+    );
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as never;
+
+    await expect(processor.process(job)).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+
+    expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+      1,
+      "failed",
+      expect.objectContaining({
+        resultCommentId: 100,
+        errorMessage: expect.stringContaining(
+          "comment ID persistence unavailable",
+        ),
+      }),
+    );
+  });
+
+  it("keeps PUBLISHING when comment ID and FAILED persistence both fail", async () => {
+    mockWorkspaceService.prepareWorktree.mockResolvedValue({
+      worktreePath: "/tmp/worktree",
+      bareRepoPath: "/tmp/bare",
+    });
+    mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+    mockCodexService.executeCodex.mockResolvedValue({
+      rawOutput:
+        '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+      exitCode: 0,
+      durationMs: 10,
+      inputTokens: null,
+      cachedInputTokens: null,
+      outputTokens: null,
+    });
+    const persistedStatuses: string[] = [];
+    mockReviewService.updateStatus.mockImplementation(
+      (_id: number, status: string) => {
+        if (
+          status === "preparing" ||
+          status === "reviewing" ||
+          status === "publishing"
+        ) {
+          persistedStatuses.push(status);
+          return Promise.resolve(undefined);
+        }
+        if (status === "failed") {
+          return Promise.reject(new Error("FAILED persistence unavailable"));
+        }
+        return Promise.reject(new Error(`unexpected status: ${status}`));
+      },
+    );
+    mockReviewService.updateResultCommentId.mockRejectedValue(
+      new Error("comment ID persistence unavailable"),
+    );
+
+    const job = {
+      data: baseJobData,
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as never;
+
+    await expect(processor.process(job)).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+
+    expect(mockReviewService.updateResultCommentId).toHaveBeenCalledWith(1, 100);
+    expect(mockBitbucketService.createComment).toHaveBeenCalledTimes(1);
+    expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+      1,
+      "failed",
+      expect.objectContaining({
+        resultCommentId: 100,
+      }),
+    );
+    expect(persistedStatuses).toEqual(["preparing", "publishing"]);
   });
 });

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -1663,15 +1663,28 @@ describe("ReviewProcessor error handling", () => {
     expect(mockBitbucketService.createComment).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves the process-local comment ID when its early persistence fails", async () => {
+  it("continues publishing when early comment ID persistence fails", async () => {
     mockWorkspaceService.prepareWorktree.mockResolvedValue({
       worktreePath: "/tmp/worktree",
       bareRepoPath: "/tmp/bare",
     });
     mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
     mockCodexService.executeCodex.mockResolvedValue({
-      rawOutput:
-        '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+      rawOutput: JSON.stringify({
+        summary: "ok",
+        verdict: "comment",
+        confidence: 100,
+        findings: [
+          {
+            title: "Finding",
+            path: "src/app.ts",
+            lineRange: { start: 1, end: 1 },
+            severity: "recommended",
+            description: "description",
+            reason: "reason",
+          },
+        ],
+      }),
       exitCode: 0,
       durationMs: 10,
       inputTokens: null,
@@ -1689,18 +1702,14 @@ describe("ReviewProcessor error handling", () => {
       opts: { attempts: 3 },
     } as never;
 
-    await expect(processor.process(job)).rejects.toBeInstanceOf(
-      UnrecoverableError,
-    );
+    await expect(processor.process(job)).resolves.toBeUndefined();
 
+    expect(mockBitbucketService.createInlineComment).toHaveBeenCalledTimes(1);
     expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
       1,
-      "failed",
+      "completed",
       expect.objectContaining({
         resultCommentId: 100,
-        errorMessage: expect.stringContaining(
-          "comment ID persistence unavailable",
-        ),
       }),
     );
   });

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -24,6 +24,8 @@ import { type ReviewPromptMode, resolveReviewPrompt } from "./review.prompt";
 // Keep margin for base instructions, custom prompt text, and JSON schema.
 const MAX_INLINE_REVIEW_PROMPT_CHARS = 900_000;
 
+type ResultCommentPublishedCallback = (commentId: number) => Promise<void>;
+
 @Processor(REVIEW_QUEUE_NAME)
 export class ReviewProcessor extends WorkerHost {
   private readonly logger = new ServiceLogger(ReviewProcessor.name);
@@ -48,6 +50,7 @@ export class ReviewProcessor extends WorkerHost {
     let codexResult: ICodexReviewResult | undefined;
     let reviewDiff = "";
     let publishStarted = false;
+    let resultCommentId: number | undefined;
 
     try {
       // 백오프 대기 중 새 커밋 리뷰가 이 런을 대체했으면 구버전 리뷰를 게시하지 않는다.
@@ -90,7 +93,19 @@ export class ReviewProcessor extends WorkerHost {
         ReviewRunStatus.PUBLISHING,
       );
       publishStarted = true;
-      const commentId = await this.publishResults(data, codexResult, reviewDiff);
+      const commentId = await this.publishResults(
+        data,
+        codexResult,
+        reviewDiff,
+        async (publishedCommentId) => {
+          // 로컬 증거를 먼저 남겨 DB 저장 실패도 catch에서 보존한다.
+          resultCommentId = publishedCommentId;
+          await this.reviewService.updateResultCommentId(
+            data.reviewRunId,
+            publishedCommentId,
+          );
+        },
+      );
 
       // Step 4: Mark completed
       await this.markCompleted(
@@ -121,6 +136,7 @@ export class ReviewProcessor extends WorkerHost {
           ReviewRunStatus.FAILED,
           {
             reviewOutput: failedCodexResult?.rawOutput,
+            resultCommentId,
             durationMs: failedCodexResult?.durationMs,
             totalDurationMs: Date.now() - processStartTime,
             inputTokens: failedCodexResult?.inputTokens ?? undefined,
@@ -289,23 +305,34 @@ export class ReviewProcessor extends WorkerHost {
     data: IReviewJobData,
     codexResult: ICodexReviewResult,
     reviewDiff: string,
+    onResultCommentPublished: ResultCommentPublishedCallback,
   ): Promise<number | undefined> {
     const unified = parseUnifiedReviewJson(codexResult.rawOutput, (msg) =>
       this.logger.error(msg),
     );
 
     if (unified) {
-      return this.publishUnifiedResults(data, unified, reviewDiff);
+      return this.publishUnifiedResults(
+        data,
+        unified,
+        reviewDiff,
+        onResultCommentPublished,
+      );
     }
 
-    return this.publishFallbackResults(data, codexResult.rawOutput);
+    return this.publishFallbackResults(
+      data,
+      codexResult.rawOutput,
+      onResultCommentPublished,
+    );
   }
 
   /** 통합 파싱 성공 시: verdict badge + summary + stats table + inline comments */
   private async publishUnifiedResults(
     data: IReviewJobData,
     unified: IUnifiedReviewResult,
-    reviewDiff = "",
+    reviewDiff: string,
+    onResultCommentPublished: ResultCommentPublishedCallback,
   ): Promise<number | undefined> {
     const findings = this.filterFindingsToReviewDiff(
       unified.findings,
@@ -343,6 +370,7 @@ export class ReviewProcessor extends WorkerHost {
       pullRequestId: data.pullRequestId,
       body: summaryBody,
     });
+    await onResultCommentPublished(summaryComment.id);
     this.logger.log(`Summary comment posted: ${summaryComment.id}`);
 
     // Post inline comments
@@ -357,6 +385,7 @@ export class ReviewProcessor extends WorkerHost {
   private async publishFallbackResults(
     data: IReviewJobData,
     rawOutput: string,
+    onResultCommentPublished: ResultCommentPublishedCallback,
   ): Promise<number | undefined> {
     this.logger.warn("Unified JSON parse failed, falling back to raw output comment");
     const comment = await this.bitbucketService.createComment({
@@ -365,6 +394,7 @@ export class ReviewProcessor extends WorkerHost {
       pullRequestId: data.pullRequestId,
       body: `## 🔍 코드 리뷰\n\n${rawOutput}`,
     });
+    await onResultCommentPublished(comment.id);
     this.logger.log(`Fallback comment posted: ${comment.id}`);
     return comment.id;
   }

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -100,10 +100,16 @@ export class ReviewProcessor extends WorkerHost {
         async (publishedCommentId) => {
           // 로컬 증거를 먼저 남겨 DB 저장 실패도 catch에서 보존한다.
           resultCommentId = publishedCommentId;
-          await this.reviewService.updateResultCommentId(
-            data.reviewRunId,
-            publishedCommentId,
-          );
+          try {
+            await this.reviewService.updateResultCommentId(
+              data.reviewRunId,
+              publishedCommentId,
+            );
+          } catch (persistenceErr) {
+            this.logger.error(
+              `Failed to persist result comment ID: ${(persistenceErr as Error).message}`,
+            );
+          }
         },
       );
 

--- a/src/review/review.service.spec.ts
+++ b/src/review/review.service.spec.ts
@@ -166,6 +166,97 @@ describe("ReviewService stats", () => {
   });
 });
 
+describe("ReviewService idempotency", () => {
+  const mockRepository = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  let service: ReviewService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ReviewService(mockRepository as never);
+  });
+
+  it("deletes a failed run without a result comment to allow retry", async () => {
+    mockRepository.findOne.mockResolvedValueOnce({
+      id: 7,
+      reviewStatus: ReviewRunStatus.FAILED,
+      resultCommentId: null,
+    });
+
+    await expect(service.existsByIdempotencyKey("repo:1:commit")).resolves.toBe(
+      false,
+    );
+
+    expect(mockRepository.findOne).toHaveBeenCalledWith({
+      where: { idempotencyKey: "repo:1:commit" },
+      select: ["id", "reviewStatus", "resultCommentId"],
+    });
+    expect(mockRepository.delete).toHaveBeenCalledWith(7);
+  });
+
+  it("keeps a failed run with a result comment and treats it as duplicate", async () => {
+    mockRepository.findOne.mockResolvedValueOnce({
+      id: 8,
+      reviewStatus: ReviewRunStatus.FAILED,
+      resultCommentId: 321,
+    });
+
+    await expect(service.existsByIdempotencyKey("repo:1:commit")).resolves.toBe(
+      true,
+    );
+
+    expect(mockRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it("keeps a publishing run without a result comment as a duplicate", async () => {
+    mockRepository.findOne.mockResolvedValueOnce({
+      id: 9,
+      reviewStatus: ReviewRunStatus.PUBLISHING,
+      resultCommentId: null,
+    });
+
+    await expect(service.existsByIdempotencyKey("repo:1:commit")).resolves.toBe(
+      true,
+    );
+
+    expect(mockRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it("waits for the result comment ID update without changing status", async () => {
+    let releaseUpdate: (() => void) | undefined;
+    const updatePending = new Promise<void>((resolve) => {
+      releaseUpdate = resolve;
+    });
+    mockRepository.update.mockReturnValueOnce(updatePending);
+    let serviceCallSettled = false;
+
+    const serviceCall = service.updateResultCommentId(9, 654).then(() => {
+      serviceCallSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(mockRepository.update).toHaveBeenCalledWith(9, {
+      resultCommentId: 654,
+    });
+    expect(serviceCallSettled).toBe(false);
+
+    releaseUpdate?.();
+    await serviceCall;
+    expect(serviceCallSettled).toBe(true);
+  });
+
+  it("propagates a result comment ID update rejection", async () => {
+    const error = new Error("database unavailable");
+    mockRepository.update.mockRejectedValueOnce(error);
+
+    await expect(service.updateResultCommentId(9, 654)).rejects.toBe(error);
+  });
+});
+
 describe("ReviewService.listRecent", () => {
   const mockRepository = {
     create: jest.fn(),

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -169,20 +169,23 @@ export class ReviewService {
     return saved;
   }
 
-  /** idempotency key로 중복 확인 (FAILED는 재시도 허용) */
+  /** idempotency key로 중복 확인 (게시되지 않은 FAILED만 재시도 허용) */
   async existsByIdempotencyKey(idempotencyKey: string): Promise<boolean> {
     const existing = await this.reviewRunRepository.findOne({
       where: { idempotencyKey },
-      select: ["id", "reviewStatus"],
+      select: ["id", "reviewStatus", "resultCommentId"],
     });
 
     if (!existing) return false;
 
-    // FAILED → 재시도 허용: 기존 레코드 삭제
-    if (existing.reviewStatus === ReviewRunStatus.FAILED) {
+    // 게시 증거가 없는 FAILED만 삭제해 재시도를 허용한다.
+    if (
+      existing.reviewStatus === ReviewRunStatus.FAILED &&
+      existing.resultCommentId == null
+    ) {
       await this.reviewRunRepository.delete(existing.id);
       this.logger.log(
-        `Removed failed review run (id=${existing.id}) for retry: ${idempotencyKey}`,
+        `Removed unpublished failed review run (id=${existing.id}) for retry: ${idempotencyKey}`,
       );
       return false;
     }
@@ -209,6 +212,14 @@ export class ReviewService {
     >,
   ): Promise<void> {
     await this.reviewRunRepository.update(id, { reviewStatus, ...extra });
+  }
+
+  /** 상태 전이 없이 게시된 결과 댓글 ID만 저장 */
+  async updateResultCommentId(
+    id: number,
+    resultCommentId: number,
+  ): Promise<void> {
+    await this.reviewRunRepository.update(id, { resultCommentId });
   }
 
   /** 특정 PR의 최근 리뷰 결과 조회 */


### PR DESCRIPTION
## Summary
- persist the first Bitbucket result comment ID before inline publishing or completion bookkeeping
- retain published FAILED runs as idempotency records while still deleting unpublished FAILED runs for retry
- preserve the process-local comment ID across comment-ID persistence and completion-state failures

## Root cause
A successful Bitbucket comment followed by a failed `markCompleted()` changed the run to `FAILED`. Webhook redelivery then deleted every FAILED row and enqueued a fresh Codex review, duplicating the already-published result.

## Verification
- `pnpm test --runInBand src/review/review.service.spec.ts src/queue/review.processor.spec.ts` — 2 suites, 98 tests passed
- `pnpm lint` — passed with no warnings/errors
- `pnpm build` — passed
- `pnpm test --runInBand` — 17 suites, 238 tests passed
- `pnpm test:cov --runInBand` — 17 suites, 238 tests passed; statements 88.01%

## Adversarial review
Hosted-tree fallback profile: GPT-5.6 Sol/high (phase-specific top-level Luna/xhigh was unavailable).

Three fresh read-only reviewers covered correctness, security/operations, and issue contracts/tests. A P2 async-promise test gap and two P2 combined-state test gaps were confirmed and remediated by the original implementation context. Two follow-up review rounds completed; final round reported no findings in all three tracks.

## Security checklist
- no new external input or authorization surface
- no secrets or error-detail exposure
- no schema migration
- updates are limited to internal review status metadata and Bitbucket result comment IDs

Closes #27