### PR TITLE
fix: expose Bitbucket authentication failures

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -4,6 +4,22 @@
 
 ## 진행 중/최근 작업
 
+### Task 33: Bitbucket 인증 실패 관측성과 재시도 분류
+- **상태**: ✅ 완료
+- **배경**: repo 전용 토큰 만료 시 진행·실패 댓글과 git fetch가 모두 같은 토큰으로 실패하고, 복구 불가능한 인증 오류를 3회 재시도한 뒤 로그만 남긴 운영 인시던트.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 인증 실패 즉시 중단 | ✅ | git `fatal: Authentication failed`와 Bitbucket API 401을 영구 실패로 분류해 첫 시도에 FAILED를 저장하고 `UnrecoverableError`로 재시도 차단 |
+| 독립 관측 표면 | ✅ | `code_review_authentication_failures_total{repository,stage}` Prometheus counter 추가. `OTEL_SDK_DISABLED=true`여도 `METRICS_PORT` exporter는 독립 실행 |
+| 댓글 자격증명 폴백 | ✅ | repo 토큰 요청이 401이면 기존 global API token 또는 username/app password로 댓글 API를 한 번 재시도. global 자격증명이 없으면 추가 요청 없이 실패 |
+| 실패 통지 await | ✅ | fire-and-forget 실패 댓글을 await해 종료 전에 게시 결과 또는 실패 로그를 확정 |
+| 회귀 테스트 | ✅ | 실제 Prometheus endpoint에서 repo git 인증 실패 metric과 첫 시도 중단 검증, repo token 401의 global 폴백/폴백 없음 검증. RED → GREEN 확인 |
+| 빌드/린트/테스트 | ✅ | `pnpm lint`, `pnpm build`, `pnpm test --runInBand` 성공 (241 tests) |
+| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement 89.79%, branch 80.24% |
+| 보안 체크리스트 | ✅ | metric label은 repository slug와 고정 stage만 노출. 토큰·응답 본문 신규 노출 없음. 외부 입력·설정 추가 없음 |
+| 커밋 | ✅ | 사용자 승인 후 conventional commit 및 원격 브랜치 push |
+
 ### Task 32: 게시 후 상태 기록 실패 중복 리뷰 차단
 - **상태**: ✅ 완료
 - **배경**: GitHub 이슈 #27. Bitbucket 요약 댓글 게시 후 `markCompleted()`가 실패하면 런이 `FAILED`가 되고, 같은 웹훅 재수신 시 기존 행을 삭제해 Codex와 리뷰 댓글을 중복 실행·게시하던 경로.

--- a/src/bitbucket/bitbucket.service.spec.ts
+++ b/src/bitbucket/bitbucket.service.spec.ts
@@ -129,6 +129,50 @@ describe("BitbucketService", () => {
 
       expect(captured[0]).toBe("Bearer repo-specific");
     });
+
+    it("retries a repository token 401 with the global api token", async () => {
+      const service = await createService({
+        "bitbucket.repoTokens": { "my-repo": "expired-repo-token" },
+        "bitbucket.apiToken": "global-token",
+      });
+      const captured: string[] = [];
+      global.fetch = jest
+        .fn()
+        .mockImplementation((_url: string, options: RequestInit) => {
+          captured.push(
+            (options.headers as Record<string, string>)["Authorization"],
+          );
+          return Promise.resolve(
+            captured.length === 1
+              ? { ok: false, status: 401, text: async () => "expired" }
+              : { ok: true, json: async () => ({ id: 1 }) },
+          );
+        });
+
+      await expect(service.createComment(commentParams)).resolves.toEqual({
+        id: 1,
+      });
+      expect(captured).toEqual([
+        "Bearer expired-repo-token",
+        "Bearer global-token",
+      ]);
+    });
+
+    it("does not retry a repository token 401 without global credentials", async () => {
+      const service = await createService({
+        "bitbucket.repoTokens": { "my-repo": "expired-repo-token" },
+      });
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => "expired",
+      });
+
+      await expect(service.createComment(commentParams)).rejects.toThrow(
+        "Bitbucket API error 401: expired",
+      );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("comment APIs", () => {

--- a/src/bitbucket/bitbucket.service.ts
+++ b/src/bitbucket/bitbucket.service.ts
@@ -19,32 +19,61 @@ export class BitbucketService {
     );
   }
 
-  /** Resolve auth header: repoTokens[repoSlug] → apiToken → username/appPassword */
-  private resolveAuthHeader(repoSlug: string): string {
+  /** Auth order: repository token, then configured global credentials. */
+  private resolveAuthHeaders(repoSlug: string): readonly string[] {
     const repoTokens =
       this.configService.get<Record<string, string>>("bitbucket.repoTokens") ??
       {};
     const repoToken = repoTokens[repoSlug];
-    if (repoToken) {
-      return `Bearer ${repoToken}`;
-    }
-
     const apiToken = this.configService.get<string>("bitbucket.apiToken", "");
-    if (apiToken) {
-      return `Bearer ${apiToken}`;
-    }
-
     const username = this.configService.get<string>("bitbucket.username", "");
     const appPassword = this.configService.get<string>(
       "bitbucket.appPassword",
       "",
     );
-    if (!username || !appPassword) {
+    const authHeaders: string[] = [];
+
+    if (repoToken) authHeaders.push(`Bearer ${repoToken}`);
+    if (apiToken && apiToken !== repoToken) {
+      authHeaders.push(`Bearer ${apiToken}`);
+    } else if (username && appPassword) {
+      authHeaders.push(
+        `Basic ${Buffer.from(`${username}:${appPassword}`).toString("base64")}`,
+      );
+    }
+
+    if (authHeaders.length === 0) {
       this.logger.warn(
         `No Bitbucket auth configured for repo "${repoSlug}" — API calls will fail`,
       );
+      authHeaders.push(`Basic ${Buffer.from(":").toString("base64")}`);
     }
-    return `Basic ${Buffer.from(`${username}:${appPassword}`).toString("base64")}`;
+    return authHeaders;
+  }
+
+  private async postWithAuthFallback(
+    url: string,
+    repoSlug: string,
+    body: string,
+  ): Promise<Response> {
+    const authHeaders = this.resolveAuthHeaders(repoSlug);
+    for (const [index, authHeader] of authHeaders.entries()) {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: authHeader,
+          "Content-Type": "application/json",
+        },
+        body,
+      });
+      if (response.status !== 401 || index === authHeaders.length - 1) {
+        return response;
+      }
+      this.logger.warn(
+        `Repository token rejected for "${repoSlug}"; retrying with global Bitbucket credentials`,
+      );
+    }
+    throw new Error("Bitbucket auth resolution produced no credentials");
   }
 
   /** PR에 리뷰 결과 댓글 생성 */
@@ -53,16 +82,13 @@ export class BitbucketService {
   ): Promise<IBitbucketComment> {
     const url = `${this.baseUrl}/repositories/${params.workspace}/${params.repoSlug}/pullrequests/${params.pullRequestId}/comments`;
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: this.resolveAuthHeader(params.repoSlug),
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    const response = await this.postWithAuthFallback(
+      url,
+      params.repoSlug,
+      JSON.stringify({
         content: { raw: params.body },
       }),
-    });
+    );
 
     if (!response.ok) {
       const errorBody = await response.text();
@@ -82,17 +108,14 @@ export class BitbucketService {
   ): Promise<IBitbucketComment> {
     const url = `${this.baseUrl}/repositories/${params.workspace}/${params.repoSlug}/pullrequests/${params.pullRequestId}/comments`;
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: this.resolveAuthHeader(params.repoSlug),
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    const response = await this.postWithAuthFallback(
+      url,
+      params.repoSlug,
+      JSON.stringify({
         content: { raw: params.body },
         parent: { id: params.parentCommentId },
       }),
-    });
+    );
 
     if (!response.ok) {
       const errorBody = await response.text();
@@ -108,20 +131,17 @@ export class BitbucketService {
   ): Promise<IBitbucketComment> {
     const url = `${this.baseUrl}/repositories/${params.workspace}/${params.repoSlug}/pullrequests/${params.pullRequestId}/comments`;
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: this.resolveAuthHeader(params.repoSlug),
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    const response = await this.postWithAuthFallback(
+      url,
+      params.repoSlug,
+      JSON.stringify({
         content: { raw: params.body },
         inline: {
           path: params.filePath,
           to: params.line,
         },
       }),
-    });
+    );
 
     if (!response.ok) {
       const errorBody = await response.text();

--- a/src/lib/opentelemetry.ts
+++ b/src/lib/opentelemetry.ts
@@ -1,8 +1,10 @@
 import { Logger } from "@nestjs/common";
+import { metrics } from "@opentelemetry/api";
 import { DEFAULTS } from "../config/configuration";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-grpc";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
+import { PrometheusExporter } from "@opentelemetry/exporter-prometheus";
 import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { IORedisInstrumentation } from "@opentelemetry/instrumentation-ioredis";
@@ -21,12 +23,17 @@ import {
 } from "@opentelemetry/resources";
 import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
 import { NodeSDK } from "@opentelemetry/sdk-node";
+import { MeterProvider } from "@opentelemetry/sdk-metrics";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 export interface IOpenTelemetryBootstrapConfig {
   metricsPort?: number;
   metricsEndpoint?: string;
   metricsEnabled?: boolean;
+}
+
+export interface IOpenTelemetryRuntime {
+  shutdown(): Promise<void>;
 }
 
 /**
@@ -36,7 +43,7 @@ export interface IOpenTelemetryBootstrapConfig {
 export async function initOpenTelemetry(
   serviceName: string,
   config?: IOpenTelemetryBootstrapConfig,
-): Promise<NodeSDK | undefined> {
+): Promise<IOpenTelemetryRuntime> {
   const metricsPort =
     config?.metricsPort ?? Number(process.env["METRICS_PORT"] || String(DEFAULTS.METRICS_PORT));
   const metricsEndpoint = config?.metricsEndpoint ?? "/metrics";
@@ -59,9 +66,20 @@ export async function initOpenTelemetry(
     resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName }),
   );
 
+  let meterProvider: MeterProvider | undefined;
   if (metricsEnabled) {
+    const prometheusExporter = new PrometheusExporter({
+      port: metricsPort,
+      endpoint: metricsEndpoint,
+    });
+    meterProvider = new MeterProvider({
+      resource,
+      readers: [prometheusExporter],
+    });
+    metrics.setGlobalMeterProvider(meterProvider);
+    await prometheusExporter.startServer();
     Logger.log(
-      `Metrics config detected (port=${metricsPort}, endpoint=${metricsEndpoint})`,
+      `Prometheus metrics exporter enabled (port=${metricsPort}, endpoint=${metricsEndpoint})`,
     );
   }
 
@@ -91,12 +109,19 @@ export async function initOpenTelemetry(
   sdk.start();
   Logger.log(`OpenTelemetry SDK initialized for ${serviceName}`);
 
+  const runtime: IOpenTelemetryRuntime = {
+    async shutdown(): Promise<void> {
+      await sdk.shutdown();
+      await meterProvider?.shutdown();
+    },
+  };
+
   process.on("SIGTERM", () => {
-    sdk
+    runtime
       .shutdown()
       .then(() => Logger.log("OpenTelemetry SDK terminated"))
       .catch((error: unknown) => Logger.error("Error terminating OTel SDK", error));
   });
 
-  return sdk;
+  return runtime;
 }

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -15,6 +15,9 @@ import { TriggerType } from "../entities/review-run.entity";
 import { IReviewJobData } from "./interfaces/queue.interfaces";
 import { rm, writeFile } from "node:fs/promises";
 import { UnrecoverableError } from "bullmq";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { initOpenTelemetry } from "../lib/opentelemetry";
 
 jest.mock("@lib/logger", () => ({
   ServiceLogger: jest.fn().mockImplementation(() => ({
@@ -25,6 +28,19 @@ jest.mock("@lib/logger", () => ({
     verbose: jest.fn(),
   })),
 }));
+
+async function reservePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
 
 describe("review.prompt", () => {
   it.each([
@@ -1468,6 +1484,62 @@ describe("ReviewProcessor error handling", () => {
     );
     expect(mockBitbucketService.replyToComment).not.toHaveBeenCalled();
     expect(mockBitbucketService.createComment).not.toHaveBeenCalled();
+  });
+
+  it("should expose repository authentication failure without retrying", async () => {
+    const metricsPort = await reservePort();
+    const previousSdkDisabled = process.env["OTEL_SDK_DISABLED"];
+    process.env["OTEL_SDK_DISABLED"] = "true";
+    const telemetry = await initOpenTelemetry("code-review-test", {
+      metricsPort,
+    });
+    processor = new ReviewProcessor(
+      mockReviewService as never,
+      mockWorkspaceService as never,
+      mockCodexService as never,
+      mockBitbucketService as never,
+      mockConfigService as never,
+    );
+
+    try {
+      mockWorkspaceService.prepareWorktree.mockRejectedValue(
+        new Error(
+          "Command failed: git fetch origin\nfatal: Authentication failed for 'https://bitbucket.org/my-workspace/my-repo.git/'",
+        ),
+      );
+
+      const job = {
+        data: baseJobData,
+        attemptsMade: 0,
+        opts: { attempts: 3 },
+      } as never;
+
+      const rejection = await processor.process(job).catch((error) => error);
+      const metricsResponse = await fetch(
+        `http://127.0.0.1:${metricsPort}/metrics`,
+      );
+      const metricsBody = await metricsResponse.text();
+
+      expect(metricsBody).toContain("code_review_authentication_failures_total");
+      expect(metricsBody).toContain('repository="my-repo"');
+      expect(metricsBody).toContain('stage="git"');
+      expect(rejection).toBeInstanceOf(UnrecoverableError);
+      expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+        1,
+        "failed",
+        expect.objectContaining({
+          errorMessage: expect.stringContaining("Authentication failed"),
+        }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalled();
+    } finally {
+      await telemetry?.shutdown();
+      if (previousSdkDisabled === undefined) {
+        delete process.env["OTEL_SDK_DISABLED"];
+      } else {
+        process.env["OTEL_SDK_DISABLED"] = previousSdkDisabled;
+      }
+    }
   });
 
   it("should report failure on the last attempt", async () => {

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -1,6 +1,7 @@
 import { Processor, WorkerHost, OnWorkerEvent } from "@nestjs/bullmq";
 import { Job, UnrecoverableError } from "bullmq";
 import { ConfigService } from "@nestjs/config";
+import { metrics } from "@opentelemetry/api";
 import { ServiceLogger } from "@lib/logger";
 import { REVIEW_QUEUE_NAME } from "../constants/queue.constants";
 import { IReviewJobData } from "./interfaces/queue.interfaces";
@@ -26,9 +27,24 @@ const MAX_INLINE_REVIEW_PROMPT_CHARS = 900_000;
 
 type ResultCommentPublishedCallback = (commentId: number) => Promise<void>;
 
+function authenticationFailureStage(error: Error): "api" | "git" | null {
+  if (/Bitbucket(?: inline comment)? API error 401\b/.test(error.message)) {
+    return "api";
+  }
+  if (/\bfatal: Authentication failed\b/i.test(error.message)) {
+    return "git";
+  }
+  return null;
+}
+
 @Processor(REVIEW_QUEUE_NAME)
 export class ReviewProcessor extends WorkerHost {
   private readonly logger = new ServiceLogger(ReviewProcessor.name);
+  private readonly authenticationFailureCounter = metrics
+    .getMeter("code-review")
+    .createCounter("code_review_authentication_failures", {
+      description: "Permanent Bitbucket authentication failures",
+    });
 
   constructor(
     private readonly reviewService: ReviewService,
@@ -126,11 +142,21 @@ export class ReviewProcessor extends WorkerHost {
         codexResult ||
         (err as Error & { codexResult?: ICodexReviewResult }).codexResult;
       this.logger.error(`Review failed: ${error.message}`);
+      const authFailureStage = authenticationFailureStage(error);
+      if (authFailureStage) {
+        this.authenticationFailureCounter.add(1, {
+          repository: data.repositorySlug,
+          stage: authFailureStage,
+        });
+      }
 
-      // 게시 전 실패이고 시도가 남았으면 FAILED 기록·실패 코멘트를 보류한다.
-      // 지금 FAILED로 적으면 ① 사용자에게 실패 코멘트가 먼저 나가고 뒤늦게 리뷰가 붙는다
-      // ② 백오프 중 같은 웹훅이 FAILED 레코드를 지우고 재시도 잡을 제거해버린다.
-      if (!publishStarted && job.attemptsMade + 1 < (job.opts?.attempts ?? 1)) {
+      // 게시 전 일시 실패이고 시도가 남았으면 FAILED 기록·실패 코멘트를 보류한다.
+      // 인증 실패는 재시도로 복구되지 않으므로 첫 시도에 바로 기록하고 중단한다.
+      if (
+        !publishStarted &&
+        !authFailureStage &&
+        job.attemptsMade + 1 < (job.opts?.attempts ?? 1)
+      ) {
         throw err;
       }
 
@@ -157,40 +183,35 @@ export class ReviewProcessor extends WorkerHost {
         );
       }
 
-      // Notify user about the failure
+      // Notify user about the failure. BitbucketService retries a repository
+      // token 401 once with configured global credentials when available.
       const errorBody = `❌ Code Review 실패\n\n\`\`\`\n${error.message.substring(0, 500)}\n\`\`\``;
-      if (data.triggerCommentId) {
-        this.bitbucketService
-          .replyToComment({
+      try {
+        if (data.triggerCommentId) {
+          await this.bitbucketService.replyToComment({
             workspace: data.workspaceSlug,
             repoSlug: data.repositorySlug,
             pullRequestId: data.pullRequestId,
             parentCommentId: data.triggerCommentId,
             body: errorBody,
-          })
-          .catch((replyErr) => {
-            this.logger.error(
-              `Failed to post error reply: ${(replyErr as Error).message}`,
-            );
           });
-      } else {
-        this.bitbucketService
-          .createComment({
+        } else {
+          await this.bitbucketService.createComment({
             workspace: data.workspaceSlug,
             repoSlug: data.repositorySlug,
             pullRequestId: data.pullRequestId,
             body: errorBody,
-          })
-          .catch((commentErr) => {
-            this.logger.error(
-              `Failed to post error comment: ${(commentErr as Error).message}`,
-            );
           });
+        }
+      } catch (notificationErr) {
+        this.logger.error(
+          `Failed to post error ${data.triggerCommentId ? "reply" : "comment"}: ${(notificationErr as Error).message}`,
+        );
       }
 
-      // 게시 단계에 진입한 뒤 실패했으면 재시도하면 리뷰 코멘트가 중복 게시되고
-      // Codex도 다시 돌아간다. 재시도 없이 여기서 끊는다.
-      if (publishStarted) {
+      // 게시 단계 진입 후 실패와 인증 실패는 재시도해도 복구되지 않거나
+      // 중복 게시 위험이 있으므로 즉시 중단한다.
+      if (publishStarted || authFailureStage) {
         throw new UnrecoverableError(error.message);
       }
       throw err; // Re-throw to let BullMQ handle retry


### PR DESCRIPTION
## Summary
- classify Git and Bitbucket 401 authentication failures as unrecoverable and persist FAILED immediately
- expose `code_review_authentication_failures_total{repository,stage}` on the Prometheus endpoint even when `OTEL_SDK_DISABLED=true`
- retry comment API 401 responses once with configured global Bitbucket credentials and await failure notifications

## Incident
A repository-scoped access token expired for `locomotivelabs/todoeng-academy-web`. The review retried three times, while both progress and failure comments failed with the same credential, leaving no PR-visible signal.

## Verification
- `pnpm lint`
- `pnpm build`
- `pnpm test --runInBand` — 241 tests
- `pnpm test:cov --runInBand` — statements 89.79%, branches 80.24%

## Tradeoff
When no global Bitbucket credential exists, PR notification remains impossible by definition; FAILED state and the Prometheus counter remain observable for infrastructure alerting.