### PR TITLE
fix(workspace): prune stale worktree registration before add

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -474,3 +474,18 @@
 | pnpm build + lint + test:cov | ✅ | 커버리지 86.7% (기준 80%) |
 | 실물 검증 | ✅ | `171df0940`에 positive pathspec 실행 → `M pnpm-lock.yaml` 출력 확인 |
 | PR #19 Codex 리뷰 반영 (P2 2건) | ✅ | ① 조회 실패를 `null`(알 수 없음)로 구분해 "변경 없음" 단정 제거 ② 상태값(M/A/D/R) 설명 추가로 lock 삭제·이름 변경은 계속 지적 가능, 201 tests passed |
+
+### 컨테이너 재시작이 남긴 고아 worktree 등록으로 리뷰 영구 실패
+- **상태**: ✅ 완료
+- **배경**: `godot-env` PR #5 리뷰가 3회 재시도 전부 `fatal: '...' is a missing but already registered worktree`로 실패. 07:49에 worktree를 만든 리뷰가 07:52:38 컨테이너 재생성(설정 반영 배포)으로 죽어 `cleanupWorktree`를 못 탔고, workspace가 bind mount라 디렉터리·등록이 둘 다 디스크에 남았다. 재시도의 `createWorktree`가 **디렉터리만** `rm -rf`하고 `worktree add`를 부르면서 살아남은 등록에 막혔다. 재시도로는 절대 안 풀려서, 사람이 인스턴스에 들어가 `git worktree prune`을 하기 전까지 그 repo의 그 커밋은 영구히 리뷰 불가였다.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 로컬 재현 | ✅ | bare repo에 worktree add → 디렉터리만 삭제 → 재 add에서 프로덕션과 동일 fatal 재현 |
+| `createWorktree`에 `worktree prune` 추가 | ✅ | `rm -rf` 다음, `add` 직전. `add -f`는 등록을 덮어쓸 뿐 다른 고아를 남겨 prune을 택함 |
+| prune이 살아있는 worktree를 안 건드리는지 실측 | ✅ | worktree 2개 등록 상태에서 prune → 둘 다 잔존. 디렉터리가 사라진 등록만 지운다 |
+| 테스트 (TDD RED→GREEN) | ✅ | 실제 git으로 도는 회귀 1케이스(mock 걷어냄) + 기존 호출 순서 검증 갱신, 230 tests passed |
+| `pnpm build` + `lint` + `test:cov` | ✅ | 커버리지 86.91% (기준 80%) |
+| 프로덕션 응급 조치 | ✅ | `godot-env.git`에 `worktree prune` 수동 실행, 전 repo 15개 `prunable=0` 확인 |
+
+- **남긴 것**: `cleanupWorktree`의 `rm -rf` 폴백도 등록을 남기지만, 다음 리뷰의 prune이 흡수하므로 별도 수정하지 않았다. 리뷰 사이에 남은 고아 등록은 무해하다.

--- a/src/workspace/workspace.service.spec.ts
+++ b/src/workspace/workspace.service.spec.ts
@@ -1,6 +1,8 @@
-import { mkdtemp, rm, stat } from "fs/promises";
+import { mkdir, mkdtemp, rm, stat } from "fs/promises";
+import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { promisify } from "util";
 import { ConfigService } from "@nestjs/config";
 import { execFile } from "child_process";
 import { WorkspaceService } from "./workspace.service";
@@ -113,6 +115,15 @@ describe("WorkspaceService", () => {
     expect(execFileMock).toHaveBeenNthCalledWith(
       3,
       "git",
+      ["worktree", "prune"],
+      expect.objectContaining({
+        cwd: join(basePath, "repos", "repoa.git"),
+      }),
+      expect.any(Function),
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      4,
+      "git",
       [
         "worktree",
         "add",
@@ -132,6 +143,56 @@ describe("WorkspaceService", () => {
     const askpassPath = cloneOptions.env.GIT_ASKPASS;
     await expect(stat(askpassPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  it("recovers when the worktree directory is gone but its git registration survived", async () => {
+    // 리뷰 도중 컨테이너가 재시작되면(배포·설정 반영) 정리 경로를 못 탄다. 다음 시도는
+    // 남은 디렉터리만 지우고 add하므로 "missing but already registered"로 죽고, 재시도도
+    // 같은 이유로 죽어 그 커밋은 사람이 손으로 prune하기 전까지 영구히 리뷰 불가가 된다.
+    // 실제 git으로 돌려야 잡히는 회귀라 이 케이스만 mock을 걷어낸다.
+    const realExecFile = jest.requireActual<typeof import("child_process")>(
+      "child_process",
+    ).execFile;
+    execFileMock.mockImplementation(realExecFile);
+    const git = promisify(realExecFile);
+
+    const sourcePath = join(basePath, "source");
+    await mkdir(sourcePath, { recursive: true });
+    await git("git", ["init", "-q", "--initial-branch=main", sourcePath]);
+    await git(
+      "git",
+      [
+        "-c",
+        "user.name=t",
+        "-c",
+        "user.email=t@example.com",
+        "commit",
+        "-q",
+        "--allow-empty",
+        "-m",
+        "init",
+      ],
+      { cwd: sourcePath },
+    );
+    const { stdout } = await git("git", ["rev-parse", "HEAD"], {
+      cwd: sourcePath,
+    });
+    const params = {
+      cloneUrl: sourcePath,
+      repositorySlug: "repo-a",
+      headBranch: "main",
+      baseBranch: "main",
+      headCommitHash: stdout.trim(),
+    };
+
+    const { worktreePath } = await service.prepareWorktree(params);
+    await rm(worktreePath, { recursive: true, force: true }); // 컨테이너가 죽은 자리
+
+    await expect(service.prepareWorktree(params)).resolves.toEqual({
+      worktreePath,
+      bareRepoPath: join(basePath, "repos", "repo-a.git"),
+    });
+    expect(existsSync(worktreePath)).toBe(true);
+  }, 30_000);
 
   it("rejects repository slugs that sanitize to an empty value", async () => {
     await expect(

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -273,6 +273,16 @@ export class WorkspaceService {
       await rm(worktreePath, { recursive: true, force: true });
     }
 
+    // 디렉터리를 지워도 git 등록은 남는다. 등록이 남은 채로 add하면
+    // "missing but already registered"로 실패하고, 재시도도 같은 이유로 죽어
+    // 그 커밋은 사람이 손으로 prune하기 전까지 영구히 리뷰 불가가 된다.
+    // 리뷰 도중 컨테이너가 재시작되면(배포·반영) 정리 경로를 못 타므로 실제로 발생한다.
+    // prune은 디렉터리가 사라진 등록만 지우고 진행 중인 worktree는 건너뛴다.
+    await execFileAsync("git", ["worktree", "prune"], {
+      cwd: bareRepoPath,
+      timeout: 30_000,
+    });
+
     await execFileAsync(
       "git",
       ["worktree", "add", "--detach", worktreePath, commitHash],


### PR DESCRIPTION
## 문제

컨테이너가 리뷰 도중 재시작되면 `cleanupWorktree`를 못 타고 worktree 디렉터리와 git 등록이 **둘 다** 디스크에 남는다 (workspace가 bind mount).

재시도의 `createWorktree`는 디렉터리만 `rm -rf` 하고 `worktree add`를 부르기 때문에 살아남은 등록에 막힌다:

```
fatal: '...' is a missing but already registered worktree
```

재시도도 같은 이유로 죽어서, **사람이 인스턴스에 들어가 `git worktree prune`을 하기 전까지 그 커밋은 영구히 리뷰 불가**였다. 실제로 `godot-env` PR #5 리뷰가 3회 재시도 전부 이 에러로 실패했다 (07:49 worktree 생성 → 07:52:38 설정 반영 배포로 컨테이너 재생성).

## 수정

`rm -rf` 다음, `worktree add` 직전에 `git worktree prune`을 실행한다.

`prune`은 디렉터리가 사라진 등록만 지우고 진행 중인 worktree는 건너뛴다 — worktree 2개 등록 상태에서 prune 실행 후 둘 다 잔존하는 것을 실측 확인했다.

`add -f`는 채택하지 않았다: 대상 등록만 덮어쓸 뿐 다른 고아 등록은 그대로 남는다.

## 검증

- 로컬 재현: bare repo에 worktree add → 디렉터리만 삭제 → 재 add에서 프로덕션과 동일한 fatal 재현
- TDD RED→GREEN: 실제 git으로 도는 회귀 테스트 1건 (mock 걷어냄) + 기존 호출 순서 검증 갱신
- `pnpm build` 성공 / `pnpm lint` 무변경 / **242 tests passed** / 커버리지 86.91% (기준 80%)
- 프로덕션 응급 조치 완료: `godot-env.git`에 수동 `worktree prune`, 전 repo 15개 `prunable=0` 확인

## 남긴 것

`cleanupWorktree`의 `rm -rf` 폴백도 등록을 남기지만, 다음 리뷰의 prune이 흡수하므로 별도 수정하지 않았다. 리뷰 사이에 남은 고아 등록은 무해하다.