### PR TITLE
docs: clarify BITBUCKET_API_TOKEN accepts workspace tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ docker compose up -d
 | 환경변수 | 설명 | 기본값 |
 |---|---|---|
 | `BITBUCKET_BASE_URL` | Bitbucket API 기본 URL | `https://api.bitbucket.org/2.0` |
-| `BITBUCKET_API_TOKEN` | API 토큰 | - |
+| `BITBUCKET_API_TOKEN` | Access Token (workspace / project / repository 3종 모두 사용 가능). workspace 토큰이면 해당 workspace의 모든 repo를 하나로 커버한다. 필요한 스코프: Repositories `Read`(clone) + Pull requests `Write`(리뷰 코멘트 게시) | - |
 | `BITBUCKET_WEBHOOK_SECRET` | Webhook HMAC secret | - |
 | `REVIEW_TRIGGER_MODE` | 트리거 모드 (아래 참조) | `mention` |
 


### PR DESCRIPTION
## 문제

README의 환경변수 표에 `BITBUCKET_API_TOKEN | API 토큰`이라고만 적혀 있어, 어떤 종류의 토큰을 넣어야 하는지와 어떤 스코프가 필요한지 알 수 없었다.

## 내용

인증 경로가 API는 `Authorization: Bearer <token>`, git clone은 GIT_ASKPASS로 `x-token-auth` / `<token>`을 쓰기 때문에 Bitbucket access token 3종(**workspace / project / repository**)이 코드 변경 없이 모두 그대로 동작한다.

- `bitbucket.service.ts` — `Bearer ${apiToken}`
- `workspace.service.ts` — `createAskpassEnv("x-token-auth", apiToken)`

특히 **workspace 토큰이면 repo별 설정 없이 workspace 전체를 하나로 커버**한다는 점과 필요한 스코프(Repositories `Read` + Pull requests `Write`)를 표에 함께 적는다. `BITBUCKET_REPO_TOKENS[slug]`가 계속 우선하므로 특정 repo만 다른 토큰을 쓰는 경로는 그대로 남는다.

스코프는 내부 문자열(`repository`, `pullrequest:write`)이 아니라 토큰 생성 UI의 체크박스 라벨을 그대로 적어 화면에서 바로 찾을 수 있게 했다.

## 범위 밖

웹훅 등록은 토큰과 무관한 별개 작업이라 넣지 않았다 (표가 아니라 새 섹션이 필요하다). workspace access token의 요금제 제한 여부는 확인하지 않았으므로 문서에 쓰지 않았다.

문서 한 줄 변경으로 코드 변경 없음.