### PR TITLE
fix(helm): point image defaults at the registry the workflow pushes to

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -19,7 +19,10 @@
 | Helm 기본값 드리프트 수정 | ✅ | `image.repository`가 실제 push 대상이 아닌 `ghcr.io/anthropics/code-review-worker`였고 `image.tag` 기본값이 존재한 적 없는 appVersion `0.1.0`이었음. 실제 레지스트리와 `latest`로 정정하고, `latest` 기본값에서 캐시된 구버전을 쓰지 않도록 `pullPolicy`를 `Always`로 변경. chart README 파라미터 표 동기화 |
 | Helm 렌더링 검증 | ✅ | `helm lint` 통과, `helm template`에서 main/migration 컨테이너 모두 `ghcr.io/azyu/bitbucket-codex-code-review:latest` + `imagePullPolicy: Always` 렌더링 확인 |
 | `latest` 태그 오염 차단 | ✅ | Codex 리뷰(P1) 반영. `docker-publish.yml`이 `workflow_dispatch`만 쓰는데 임의 브랜치 ref로 실행 가능하고 `type=raw,value=latest`에 조건이 없어, 미머지 브랜치 빌드가 `latest`를 덮어쓸 수 있었음. 차트 기본값이 `latest`+`Always`가 되면 그 이미지가 재시작 시 그대로 배포되므로 `enable={{is_default_branch}}`로 제한 |
-| `latest` 입력 예약 | ✅ | Codex 재리뷰(P1) 반영. `enable={{is_default_branch}}`는 암묵 `latest` 규칙만 막고, `tag` 입력에 `latest`를 직접 넣으면 40행 raw 규칙이 그대로 통과시켰음. 입력값이 `latest`면 job 첫 스텝에서 실패시켜 예약어로 고정 (main dispatch는 42행이 이미 붙이므로 입력할 이유 없음) |
+| `latest` 입력 예약 | ✅ | Codex 재리뷰(P1) 반영. `enable={{is_default_branch}}`는 암묵 `latest` 규칙만 막고, `tag` 입력에 `latest`를 직접 넣으면 raw 규칙이 그대로 통과시켰음. 입력값이 `latest`면 job 첫 스텝에서 실패시켜 예약어로 고정 (main dispatch는 default-branch 규칙이 이미 붙이므로 입력할 이유 없음) |
+| `tag` 입력 형식 검증 | ✅ | omp 리뷰(P1) 반영. 위 완전일치 가드는 실효가 없었음 — `metadata-action`의 `src/tag.ts` `Parse()`가 CSV 필드를 `attrs[key] = value`로 덮어쓰고(뒤 값 우선) 양끝 공백을 trim하므로 `foo,value=latest`와 `" latest"` 둘 다 가드를 통과해 `latest`로 렌더됐음(소스 확인). Docker 태그 정규식 검증으로 교체하고 값은 `env`로 전달해 셸 인젝션도 차단. 9개 입력 케이스로 allow/block 동작 확인 |
+| `pullPolicy` 오프라인 탈출구 | ✅ | omp 리뷰(P2) 반영. `Always`는 노드에 이미지가 있어도 레지스트리 조회 실패 시 `ImagePullBackOff`. chart README에 에어갭·레지스트리 장애 시 `--set image.pullPolicy=IfNotPresent` 명시 |
+| `OPENAI_API_KEY` 문서 드리프트 | ⬜ | omp 리뷰(P2), **선재 결함이라 이 PR에서 미처리**. chart README:22-30은 "방법 1(권장): `deployment.yaml`의 `env`에서 `OPENAI_API_KEY`로 매핑"이라고 하나 `templates/deployment.yaml`의 `env`에는 DB·Redis·Bitbucket 3종뿐이고 차트 전체에 해당 참조 0건. README 절차대로 하면 Codex가 인증되지 않음. 별도 이슈 필요 |
 | 컨테이너 런타임 검증 | ⚠️ | 로컬 Docker 데몬 부재로 컨테이너 내부 `codex --version` 실행은 미확인. 빌드 로그상 설치 레이어 성공만 관측 |
 
 ### Task 33: Bitbucket 인증 실패 관측성과 재시도 분류

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -18,6 +18,7 @@
 | 배포 이미지 빌드 | ✅ | main `71fc648`에서 Docker Publish dispatch. amd64/arm64 양쪽 `RUN npm install -g @openai/codex@0.153.2` 성공, `ghcr.io/azyu/bitbucket-codex-code-review:{71fc648,latest}` = `sha256:091a426e...` |
 | Helm 기본값 드리프트 수정 | ✅ | `image.repository`가 실제 push 대상이 아닌 `ghcr.io/anthropics/code-review-worker`였고 `image.tag` 기본값이 존재한 적 없는 appVersion `0.1.0`이었음. 실제 레지스트리와 `latest`로 정정하고, `latest` 기본값에서 캐시된 구버전을 쓰지 않도록 `pullPolicy`를 `Always`로 변경. chart README 파라미터 표 동기화 |
 | Helm 렌더링 검증 | ✅ | `helm lint` 통과, `helm template`에서 main/migration 컨테이너 모두 `ghcr.io/azyu/bitbucket-codex-code-review:latest` + `imagePullPolicy: Always` 렌더링 확인 |
+| `latest` 태그 오염 차단 | ✅ | Codex 리뷰(P1) 반영. `docker-publish.yml`이 `workflow_dispatch`만 쓰는데 임의 브랜치 ref로 실행 가능하고 `type=raw,value=latest`에 조건이 없어, 미머지 브랜치 빌드가 `latest`를 덮어쓸 수 있었음. 차트 기본값이 `latest`+`Always`가 되면 그 이미지가 재시작 시 그대로 배포되므로 `enable={{is_default_branch}}`로 제한 |
 | 컨테이너 런타임 검증 | ⚠️ | 로컬 Docker 데몬 부재로 컨테이너 내부 `codex --version` 실행은 미확인. 빌드 로그상 설치 레이어 성공만 관측 |
 
 ### Task 33: Bitbucket 인증 실패 관측성과 재시도 분류

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -19,6 +19,7 @@
 | Helm 기본값 드리프트 수정 | ✅ | `image.repository`가 실제 push 대상이 아닌 `ghcr.io/anthropics/code-review-worker`였고 `image.tag` 기본값이 존재한 적 없는 appVersion `0.1.0`이었음. 실제 레지스트리와 `latest`로 정정하고, `latest` 기본값에서 캐시된 구버전을 쓰지 않도록 `pullPolicy`를 `Always`로 변경. chart README 파라미터 표 동기화 |
 | Helm 렌더링 검증 | ✅ | `helm lint` 통과, `helm template`에서 main/migration 컨테이너 모두 `ghcr.io/azyu/bitbucket-codex-code-review:latest` + `imagePullPolicy: Always` 렌더링 확인 |
 | `latest` 태그 오염 차단 | ✅ | Codex 리뷰(P1) 반영. `docker-publish.yml`이 `workflow_dispatch`만 쓰는데 임의 브랜치 ref로 실행 가능하고 `type=raw,value=latest`에 조건이 없어, 미머지 브랜치 빌드가 `latest`를 덮어쓸 수 있었음. 차트 기본값이 `latest`+`Always`가 되면 그 이미지가 재시작 시 그대로 배포되므로 `enable={{is_default_branch}}`로 제한 |
+| `latest` 입력 예약 | ✅ | Codex 재리뷰(P1) 반영. `enable={{is_default_branch}}`는 암묵 `latest` 규칙만 막고, `tag` 입력에 `latest`를 직접 넣으면 40행 raw 규칙이 그대로 통과시켰음. 입력값이 `latest`면 job 첫 스텝에서 실패시켜 예약어로 고정 (main dispatch는 42행이 이미 붙이므로 입력할 이유 없음) |
 | 컨테이너 런타임 검증 | ⚠️ | 로컬 Docker 데몬 부재로 컨테이너 내부 `codex --version` 실행은 미확인. 빌드 로그상 설치 레이어 성공만 관측 |
 
 ### Task 33: Bitbucket 인증 실패 관측성과 재시도 분류

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -15,7 +15,10 @@
 | 0.152.0 chore 확인 | ✅ | `update_plan` 툴이 기본 비활성으로 전환됐으나 헤드리스 `codex exec` 경로에는 영향 없음 |
 | 빌드/린트/테스트 | ✅ | `pnpm lint`, `pnpm build`, `pnpm test --runInBand` 성공 (242 tests) |
 | 보안 체크리스트 | ✅ | 시크릿·외부 입력·에러 노출 변경 없음. 버전 문자열 한 줄 변경 |
-| Docker 이미지 검증 | ⚠️ | 이미지 빌드 및 컨테이너 내부 `codex --version` 확인은 미실행 (CI/배포 시 검증 필요) |
+| 배포 이미지 빌드 | ✅ | main `71fc648`에서 Docker Publish dispatch. amd64/arm64 양쪽 `RUN npm install -g @openai/codex@0.153.2` 성공, `ghcr.io/azyu/bitbucket-codex-code-review:{71fc648,latest}` = `sha256:091a426e...` |
+| Helm 기본값 드리프트 수정 | ✅ | `image.repository`가 실제 push 대상이 아닌 `ghcr.io/anthropics/code-review-worker`였고 `image.tag` 기본값이 존재한 적 없는 appVersion `0.1.0`이었음. 실제 레지스트리와 `latest`로 정정하고, `latest` 기본값에서 캐시된 구버전을 쓰지 않도록 `pullPolicy`를 `Always`로 변경. chart README 파라미터 표 동기화 |
+| Helm 렌더링 검증 | ✅ | `helm lint` 통과, `helm template`에서 main/migration 컨테이너 모두 `ghcr.io/azyu/bitbucket-codex-code-review:latest` + `imagePullPolicy: Always` 렌더링 확인 |
+| 컨테이너 런타임 검증 | ⚠️ | 로컬 Docker 데몬 부재로 컨테이너 내부 `codex --version` 실행은 미확인. 빌드 로그상 설치 레이어 성공만 관측 |
 
 ### Task 33: Bitbucket 인증 실패 관측성과 재시도 분류
 - **상태**: ✅ 완료

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Image tag (default: git SHA)"
+        description: "Image tag (default: git SHA). 'latest' is reserved for main"
         required: false
         type: string
 
@@ -20,6 +20,12 @@ jobs:
       packages: write
 
     steps:
+      - name: Reject reserved tag
+        if: inputs.tag == 'latest'
+        run: |
+          echo "::error::'latest' is managed by the default-branch rule; use a different tag"
+          exit 1
+
       - uses: actions/checkout@v6
 
       - uses: docker/setup-qemu-action@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
             type=sha,prefix=
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,11 +20,22 @@ jobs:
       packages: write
 
     steps:
-      - name: Reject reserved tag
-        if: inputs.tag == 'latest'
+      # The input is interpolated into metadata-action's tag-rule syntax, where a
+      # later value= wins and whitespace is trimmed. Anything but a plain tag
+      # ("foo,value=latest", " latest") would smuggle latest past an equality check.
+      - name: Validate tag input
+        if: inputs.tag != ''
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          echo "::error::'latest' is managed by the default-branch rule; use a different tag"
-          exit 1
+          if [[ ! "$TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
+            echo "::error::invalid image tag: $TAG"
+            exit 1
+          fi
+          if [[ "$TAG" == "latest" ]]; then
+            echo "::error::'latest' is managed by the default-branch rule; use a different tag"
+            exit 1
+          fi
 
       - uses: actions/checkout@v6
 

--- a/charts/code-review-worker/README.md
+++ b/charts/code-review-worker/README.md
@@ -103,8 +103,9 @@ EOF
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `image.repository` | `ghcr.io/anthropics/code-review-worker` | 이미지 저장소 |
-| `image.tag` | `appVersion` | 이미지 태그 |
+| `image.repository` | `ghcr.io/azyu/bitbucket-codex-code-review` | 이미지 저장소 |
+| `image.tag` | `latest` | 이미지 태그. 운영 배포는 `--set image.tag=<git sha>` 로 고정 권장 |
+| `image.pullPolicy` | `Always` | `latest` 기본값이라 캐시된 구버전을 쓰지 않도록 Always |
 | `replicaCount` | `1` | 레플리카 수 |
 | `nodeEnv` | `production` | NODE_ENV |
 | `port` | `3000` | HTTP 포트 |

--- a/charts/code-review-worker/README.md
+++ b/charts/code-review-worker/README.md
@@ -105,7 +105,7 @@ EOF
 |-----------|---------|-------------|
 | `image.repository` | `ghcr.io/azyu/bitbucket-codex-code-review` | 이미지 저장소 |
 | `image.tag` | `latest` | 이미지 태그. 운영 배포는 `--set image.tag=<git sha>` 로 고정 권장 |
-| `image.pullPolicy` | `Always` | `latest` 기본값이라 캐시된 구버전을 쓰지 않도록 Always |
+| `image.pullPolicy` | `Always` | `latest` 기본값이라 캐시된 구버전을 쓰지 않도록 Always. 에어갭·레지스트리 장애 환경은 이미지가 노드에 있어도 기동에 실패하므로 `--set image.tag=<sha> --set image.pullPolicy=IfNotPresent` 로 배포 |
 | `replicaCount` | `1` | 레플리카 수 |
 | `nodeEnv` | `production` | NODE_ENV |
 | `port` | `3000` | HTTP 포트 |

--- a/charts/code-review-worker/values.yaml
+++ b/charts/code-review-worker/values.yaml
@@ -1,9 +1,10 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/anthropics/code-review-worker
-  pullPolicy: IfNotPresent
-  tag: ""  # defaults to Chart.appVersion
+  repository: ghcr.io/azyu/bitbucket-codex-code-review
+  # latest 태그를 기본값으로 쓰므로 IfNotPresent는 캐시된 구버전을 계속 사용한다
+  pullPolicy: Always
+  tag: latest  # 운영 배포는 --set image.tag=<sha> 로 고정 권장
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## 문제

Helm 차트 기본값이 **존재하지 않는 이미지**를 렌더링하고 있었습니다.

| 위치 | 기존 값 | 실제 |
|------|---------|------|
| `values.yaml:4` `image.repository` | `ghcr.io/anthropics/code-review-worker` | `docker-publish.yml`은 여기로 push하지 않음 |
| `values.yaml:6` `image.tag` | `""` → `Chart.AppVersion` = `0.1.0` | 워크플로가 만든 적 없는 태그 |

`docker-publish.yml`이 실제로 push하는 대상은 `ghcr.io/azyu/bitbucket-codex-code-review`이고, 태그는 `<git sha>`와 `latest`입니다.

## 변경

- `image.repository` → `ghcr.io/azyu/bitbucket-codex-code-review`
- `image.tag` → `latest` (워크플로가 내보내는 유일한 안정 태그)
- `image.pullPolicy` → `Always`
- chart README 파라미터 표 동기화

### pullPolicy를 함께 바꾼 이유

`latest`를 기본 태그로 두면 `IfNotPresent`는 노드에 캐시된 구버전 `latest`를 롤아웃 이후에도 계속 사용합니다. 방금 고친 "기본값이 의도한 이미지를 가리키지 않는" 문제를 다른 형태로 재생산하므로 `Always`로 전환했습니다.

운영 배포는 `--set image.tag=<git sha>` 로 고정하는 것을 권장하며, README와 values 주석에 명시했습니다.

## 하지 않은 것

- `Chart.yaml` appVersion 변경 — 올려도 해당 태그가 생기지 않음
- 워크플로에 버전 태깅 추가 — 별개 작업
- 이미지 재빌드 — `values.yaml`은 이미지에 포함되지 않으므로 `71fc648`이 그대로 배포 아티팩트

## 검증

- `helm lint charts/code-review-worker/` 통과
- `helm template` 렌더링에서 main 컨테이너와 migration initContainer(`migration.enabled=true`) 양쪽 모두 `ghcr.io/azyu/bitbucket-codex-code-review:latest` + `imagePullPolicy: Always` 확인