### PR TITLE
fix(webhook): decouple BullMQ job identifiers

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -6,6 +6,19 @@
 ## 진행 중/최근 작업
 
 
+### Task 37: BullMQ major 대비 colonless review jobId
+- **상태**: ✅ 완료
+- **배경**: BullMQ 5.69.2는 3세그먼트 커스텀 jobId의 콜론을 구 repeatable job 호환 예외로 허용하지만, 다음 breaking 버전에서 모든 콜론을 거부할 예정.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 키 역할 분리 | ✅ | DB `idempotencyKey`는 기존 `${slug}:${prId}:${head}` 및 force 의미를 유지하고, BullMQ `jobId`만 `review-${base64url(idempotencyKey)}`로 분리. DB 마이그레이션 없음 |
+| 배포 전환 안전성 | ✅ | stale job 제거 시 새 colonless ID와 기존 idempotencyKey ID를 모두 조회·제거해 rolling deploy 및 잔존 완료/실패 job을 처리. 큐를 비우는 배포 절차 불필요 |
+| 재발 방지 | ✅ | mention/force 모두 Queue.add에 전달되는 jobId에 콜론이 없음을 검증하고, 기존·신규 stale ID 동시 정리를 검증. Redis 통합 테스트와 Renovate major 차단은 추가하지 않음 |
+| 빌드/린트/테스트 | ✅ | `pnpm lint`, `pnpm build`, `pnpm test --runInBand` 성공 (247 tests) |
+| 커버리지 | ✅ | `pnpm test:cov --runInBand` 성공, statement 89.96%, branch 80.69% |
+| 보안 체크리스트 | ✅ | DB 스키마·외부 입력·시크릿·에러 노출 변경 없음. base64url은 식별자 인코딩에만 사용 |
+
 ### Task 36: Codex bubblewrap user namespace 배포 조건
 - **상태**: ✅ 완료 (정적 검증 완료; 실제 클러스터 런타임 미검증)
 - **배경**: 대형 PR branch-diff 모드에서 Codex read-only sandbox의 bubblewrap이 user namespace를 만들지 못하면 Git diff를 읽지 못하고 내용 없는 리뷰를 생성함. tools-infra에서 `seccomp:unconfined`만으로 해결됨.

--- a/src/webhook/webhook.controller.spec.ts
+++ b/src/webhook/webhook.controller.spec.ts
@@ -156,7 +156,7 @@ describe("WebhookController", () => {
         triggerType: TriggerType.MENTION,
         triggerCommentId: 321,
       }),
-      { jobId: "repo-a:17:abcdef1234567890" },
+      { jobId: "review-cmVwby1hOjE3OmFiY2RlZjEyMzQ1Njc4OTA" },
     );
     expect(bitbucketService.replyToComment).toHaveBeenCalledWith({
       workspace: "workspace",
@@ -230,17 +230,17 @@ describe("WebhookController", () => {
     expect(reviewQueue.add).toHaveBeenCalledWith(
       "review",
       expect.objectContaining({ idempotencyKey: forceKey }),
-      { jobId: forceKey },
+      {
+        jobId:
+          "review-cmVwby1hOjE3OmFiY2RlZjEyMzQ1Njc4OTAtZm9yY2UtMzIx",
+      },
     );
   });
 
-  // BullMQ는 커스텀 jobId의 콜론을 정확히 세 세그먼트일 때만 허용한다(job.js
-  // validateOptions의 구 repeatable job 호환 예외). 네 세그먼트짜리 force 키가
-  // 프로덕션에서 add를 던져 리뷰가 무응답으로 죽은 적이 있다 — 세그먼트 수를 고정한다.
   it.each([
     ["mention", "@codex", false],
     ["force", "@codex --force", true],
-  ])("keeps the %s jobId within BullMQ's colon limit", async (_name, raw, force) => {
+  ])("uses a colonless %s jobId", async (_name, raw, force) => {
     triggerService.isForceReview.mockReturnValue(force);
 
     await controller.handleBitbucketWebhook(
@@ -254,7 +254,7 @@ describe("WebhookController", () => {
       unknown,
       { jobId: string },
     ];
-    expect(opts.jobId.split(":")).toHaveLength(3);
+    expect(opts.jobId).not.toContain(":");
   });
 
   it("marks the review run failed when enqueueing throws", async () => {
@@ -281,9 +281,12 @@ describe("WebhookController", () => {
     expect(bitbucketService.replyToComment).not.toHaveBeenCalled();
   });
 
-  it("removes stale queued job before adding the new review job", async () => {
-    const remove = jest.fn().mockResolvedValue(undefined);
-    reviewQueue.getJob.mockResolvedValue({ remove });
+  it("removes current and legacy stale jobs during the jobId transition", async () => {
+    const removeCurrent = jest.fn().mockResolvedValue(undefined);
+    const removeLegacy = jest.fn().mockResolvedValue(undefined);
+    reviewQueue.getJob
+      .mockResolvedValueOnce({ remove: removeCurrent })
+      .mockResolvedValueOnce({ remove: removeLegacy });
 
     await controller.handleBitbucketWebhook(
       buildCommentWebhook(),
@@ -291,10 +294,16 @@ describe("WebhookController", () => {
       {},
     );
 
-    expect(reviewQueue.getJob).toHaveBeenCalledWith(
+    expect(reviewQueue.getJob).toHaveBeenNthCalledWith(
+      1,
+      "review-cmVwby1hOjE3OmFiY2RlZjEyMzQ1Njc4OTA",
+    );
+    expect(reviewQueue.getJob).toHaveBeenNthCalledWith(
+      2,
       "repo-a:17:abcdef1234567890",
     );
-    expect(remove).toHaveBeenCalled();
+    expect(removeCurrent).toHaveBeenCalled();
+    expect(removeLegacy).toHaveBeenCalled();
     expect(reviewQueue.add).toHaveBeenCalled();
   });
 

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -142,13 +142,12 @@ export class WebhookController {
     forceReview = false,
   ): Promise<{ accepted: boolean; reason?: string }> {
     const baseKey = `${prPayload.repositorySlug}:${prPayload.pullRequestId}:${prPayload.headCommitHash}`;
-    // 이 키는 BullMQ jobId로도 쓰인다. BullMQ는 커스텀 jobId의 콜론을 정확히 세
-    // 세그먼트일 때만 허용하므로(구 repeatable job 호환 예외, job.js validateOptions)
-    // force 접미사는 콜론이 아닌 구분자를 쓴다 — 콜론을 쓰면 add가 던진다.
     const idempotencyKey =
       forceReview && triggerCommentId
         ? `${baseKey}-force-${triggerCommentId}`
         : baseKey;
+    // DB idempotency 의미는 유지하고 BullMQ의 콜론 없는 ID 제약과 분리한다.
+    const jobId = `review-${Buffer.from(idempotencyKey).toString("base64url")}`;
 
     const isDuplicate =
       await this.reviewService.existsByIdempotencyKey(idempotencyKey);
@@ -157,17 +156,20 @@ export class WebhookController {
       return { accepted: false, reason: "Duplicate request" };
     }
 
-    // Remove stale BullMQ job if it exists
-    try {
-      const existingJob = await this.reviewQueue.getJob(idempotencyKey);
-      if (existingJob) {
-        await existingJob.remove();
-        this.logger.log(`Removed stale BullMQ job: ${idempotencyKey}`);
+    // 새 ID와 전환 전 idempotencyKey ID를 모두 정리해 rolling deploy 중 재큐잉을
+    // 안전하게 유지한다. 이전 job은 queue retention이 끝난 뒤 자연히 조회되지 않는다.
+    for (const staleJobId of [jobId, idempotencyKey]) {
+      try {
+        const existingJob = await this.reviewQueue.getJob(staleJobId);
+        if (existingJob) {
+          await existingJob.remove();
+          this.logger.log(`Removed stale BullMQ job: ${staleJobId}`);
+        }
+      } catch (err) {
+        this.logger.error(
+          `Failed to remove stale job: ${(err as Error).message}`,
+        );
       }
-    } catch (err) {
-      this.logger.error(
-        `Failed to remove stale job: ${(err as Error).message}`,
-      );
     }
 
     const reviewRun = await this.reviewService.createReviewRun({
@@ -197,7 +199,7 @@ export class WebhookController {
     // queued row가 Bitbucket 재시도까지 duplicate로 삼켜 PR이 무응답으로 남는다.
     try {
       await this.reviewQueue.add("review", jobData, {
-        jobId: idempotencyKey,
+        jobId,
       });
     } catch (err) {
       await this.reviewService.updateStatus(


### PR DESCRIPTION
## 문제
BullMQ 5.69.2는 정확히 3세그먼트인 커스텀 jobId의 콜론만 구 repeatable job 호환 예외로 허용합니다. 다음 breaking 버전에서 이 예외가 제거되면 기존 `${slug}:${prId}:${head}` jobId가 Queue.add에서 거부됩니다.

## 변경
- DB `idempotencyKey` 의미와 스키마는 그대로 유지
- BullMQ `jobId`만 `review-${base64url(idempotencyKey)}`로 분리
- stale job 제거 시 새 ID와 기존 colon ID를 모두 조회해 rolling deploy 전환 처리
- mention/force colonless ID와 양쪽 stale ID 제거 회귀 테스트 추가

큐를 비우는 배포 절차, Redis 통합 테스트, Renovate major 차단, README 설명은 추가하지 않았습니다. 애플리케이션 불변식 테스트가 콜론 재도입을 직접 차단하고, 전환 호환은 코드에서 처리합니다.

## 검증
- `pnpm lint`
- `pnpm build`
- `pnpm test --runInBand` — 247 tests
- `pnpm test:cov --runInBand` — statements 89.96%, branches 80.69%

## 보안
외부 입력 검증, 시크릿, DB 스키마, 에러 노출 변경 없음. base64url은 식별자 인코딩에만 사용합니다.