### PR TITLE
chore: default reviews to gpt-6-astra

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,10 +1,18 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-09-04
+> 마지막 업데이트: 2026-09-05
 
 
 ## 진행 중/최근 작업
 
+
+### Task 38: 기본 리뷰 모델 GPT-6 Astra 전환
+- **상태**: 구현·로컬 검증 완료, Draft PR 제출 대상 / 실호출 결과 전 머지 보류
+- **변경**: 애플리케이션·Helm·Compose·환경 예시·README 기본 모델과 설정/웹훅 테스트를 `gpt-6-astra`로 정합화.
+- **잔존 문자열 조사**: 이전 모델 ID는 과거 Task 27/28, 2026-07-10 설계/계획 문서, GPT-5.6 명시적 모델 전달 테스트에만 의도적으로 유지.
+- **검증**: `pnpm build`, `pnpm lint`, `pnpm test --runInBand`, `pnpm test:cov --runInBand` 성공 (17 suites, 247 tests). 커버리지 statement 89.96%, branch 80.69%, function 81.6%, line 89.97%. Helm lint 및 ConfigMap 렌더링에서 새 모델 확인.
+- **보안/범위**: 신규 시크릿·외부 입력·에러 노출 변경 없음. 모델 allowlist 미추가, reasoning effort 및 Dockerfile `@openai/codex@0.153.2` 핀 유지. 인스턴스·배포 미접촉.
+- **머지 조건**: teal-tapir의 ChatGPT 계정 인증 실호출 접근성·할당량 확인 결과 대기. 프로덕션 모델은 tools-infra `codex-code-review/fetch-env.sh`의 `CODEX_MODEL`이 결정하므로 이 PR만으로 변경되지 않음.
 
 ### Task 37: BullMQ major 대비 colonless review jobId
 - **상태**: ✅ 완료

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ QUEUE_RETRY_DELAY=5000
 # Codex CLI Configuration
 CODEX_BINARY_PATH=codex
 CODEX_TIMEOUT_MS=600000
-CODEX_MODEL=gpt-5.6-sol
+CODEX_MODEL=gpt-6-astra
 CODEX_REASONING_EFFORT=medium
 OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://custom-endpoint.example.com/v1

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker compose up -d
 | 환경변수 | 설명 | 기본값 |
 |---|---|---|
 | `CODEX_BINARY_PATH` | Codex CLI 바이너리 경로 | `codex` |
-| `CODEX_MODEL` | 사용 모델 | `gpt-5.6-sol` |
+| `CODEX_MODEL` | 사용 모델 | `gpt-6-astra` |
 | `CODEX_REASONING_EFFORT` | 추론 노력도 (`none` / `low` / `medium` / `high` / `xhigh` / `max`) | `medium` |
 | `CODEX_TIMEOUT_MS` | 실행 타임아웃 (ms) | `600000` |
 | `OPENAI_API_KEY` | OpenAI API 키 (Codex CLI 인증) | - |

--- a/charts/code-review-worker/README.md
+++ b/charts/code-review-worker/README.md
@@ -109,7 +109,7 @@ EOF
 | `nodeEnv` | `production` | NODE_ENV |
 | `port` | `3000` | HTTP 포트 |
 | `metricsPort` | `9463` | 메트릭 포트 |
-| `codex.model` | `gpt-5.6-sol` | Codex 모델 |
+| `codex.model` | `gpt-6-astra` | Codex 모델 |
 | `codex.timeoutMs` | `600000` | Codex 타임아웃 (ms) |
 | `codex.reasoningEffort` | `medium` | Codex reasoning 수준 |
 | `codexAuth.existingSecret` | `""` | Codex 인증 Secret 이름 |

--- a/charts/code-review-worker/values.yaml
+++ b/charts/code-review-worker/values.yaml
@@ -66,7 +66,7 @@ queue:
 codex:
   binaryPath: codex
   timeoutMs: 600000
-  model: gpt-5.6-sol
+  model: gpt-6-astra
   reasoningEffort: medium
 
 # --- Bitbucket ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 
       CODEX_BINARY_PATH: codex
       CODEX_TIMEOUT_MS: 600000
-      CODEX_MODEL: gpt-5.6-sol
+      CODEX_MODEL: gpt-6-astra
       CODEX_REASONING_EFFORT: medium
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -11,14 +11,14 @@ describe("configuration", () => {
     }
   });
 
-  it("defaults Codex to GPT-5.6 Sol", () => {
+  it("defaults Codex to GPT-6 Astra", () => {
     delete process.env["CODEX_MODEL"];
 
     const config = configuration();
 
     expect(config).toEqual(
       expect.objectContaining({
-        codex: expect.objectContaining({ model: "gpt-5.6-sol" }),
+        codex: expect.objectContaining({ model: "gpt-6-astra" }),
       }),
     );
   });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -13,7 +13,7 @@ export const DEFAULTS = {
   QUEUE_RETRY_DELAY: 5000,
   CODEX_BINARY_PATH: "codex",
   CODEX_TIMEOUT_MS: 600_000,
-  CODEX_MODEL: "gpt-5.6-sol",
+  CODEX_MODEL: "gpt-6-astra",
   CODEX_REASONING_EFFORT: "medium",
   REVIEW_CUSTOM_PROMPT_FILEPATH: "",
   BITBUCKET_BASE_URL: "https://api.bitbucket.org/2.0",

--- a/src/config/validation.spec.ts
+++ b/src/config/validation.spec.ts
@@ -21,7 +21,7 @@ describe("validationSchema", () => {
       expect.objectContaining({
         PORT: 3000,
         CODEX_BINARY_PATH: "codex",
-        CODEX_MODEL: "gpt-5.6-sol",
+        CODEX_MODEL: "gpt-6-astra",
         CODEX_REASONING_EFFORT: "medium",
         BITBUCKET_REPO_TOKENS: "",
         REVIEW_TRIGGER_MODE: "mention",

--- a/src/webhook/webhook.controller.spec.ts
+++ b/src/webhook/webhook.controller.spec.ts
@@ -44,7 +44,7 @@ describe("WebhookController", () => {
   };
   const configValues: Record<string, unknown> = {
     "trigger.mode": "mention",
-    "codex.model": "gpt-5.6-sol",
+    "codex.model": "gpt-6-astra",
     "codex.reasoningEffort": "high",
   };
   const configService = {
@@ -102,7 +102,7 @@ describe("WebhookController", () => {
     jest.clearAllMocks();
     Object.assign(configValues, {
       "trigger.mode": "mention",
-      "codex.model": "gpt-5.6-sol",
+      "codex.model": "gpt-6-astra",
       "codex.reasoningEffort": "high",
     });
     reviewQueue.getJob.mockResolvedValue(null);
@@ -163,7 +163,7 @@ describe("WebhookController", () => {
       repoSlug: "repo-a",
       pullRequestId: 17,
       parentCommentId: 321,
-      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.6-sol\n- Reasoning: high",
+      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-6-astra\n- Reasoning: high",
     });
   });
 
@@ -189,7 +189,7 @@ describe("WebhookController", () => {
       workspace: "workspace",
       repoSlug: "repo-a",
       pullRequestId: 17,
-      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.6-sol",
+      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-6-astra",
     });
   });
 


### PR DESCRIPTION
## 변경
- configuration DEFAULTS, Helm, Compose, .env.example, 양쪽 README의 기본 모델을 gpt-6-astra로 변경
- 설정/validation/웹훅 테스트의 기본값 및 모델 픽스처 갱신
- repo 전체 grep 조사: gpt-5.6-sol은 과거 Task 27/28, 2026-07-10 설계/계획 문서 및 GPT-5.6 명시적 모델 전달 호환성 테스트에만 의도적으로 유지
- .context/TASKS.md 작업 기록 갱신

## 머지 보류 — 실호출 결과 대기
**teal-tapir가 인스턴스에서 ChatGPT 계정 인증으로 gpt-6-astra 실호출 접근성 및 할당량을 확인하기 전에는 머지하지 마세요.** Draft로 제출하며 자동 머지를 설정하지 않습니다.
사용자 제공 배경: 플랜별 Codex 할당량이 다르고 Astra는 Sol보다 allowance를 빠르게 소모하므로 운영 계정 실측이 필요합니다.

프로덕션은 tools-infra의 codex-code-review/fetch-env.sh:41 CODEX_MODEL이 configuration.ts 기본값을 덮어씁니다. 이 PR만으로 프로덕션 모델은 바뀌지 않습니다. EC2 배포는 teal-tapir가 tools-infra에서 별도 수행합니다.

## 변경하지 않은 것
- 인스턴스 및 배포 미접촉, 실 Codex 호출 미실행
- Dockerfile @openai/codex@0.153.2 고정 유지 (요청된 최소 0.153.0 충족)
- reasoning effort 유지
- 모델 allowlist 미추가
- 신규 시크릿, 입력 검증 및 에러 노출 변경 없음

## 검증
- pnpm build 성공
- pnpm lint 경고/에러 없음
- pnpm test --runInBand: 17 suites / 247 tests 통과
- pnpm test:cov --runInBand: statements 89.96%, branches 80.69%, functions 81.6%, lines 89.97%
- helm lint charts/code-review-worker 성공
- helm template ConfigMap: CODEX_MODEL=gpt-6-astra, CODEX_REASONING_EFFORT=medium 확인