### PR TITLE
feat(review): record the codex model and reasoning effort per run

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -944,6 +944,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
                     <th>상태 · 트리거</th>
                     <th>지연(코덱스/전체)</th>
                     <th>토큰(in / cache / out)</th>
+                    <th>모델</th>
                     <th>커밋</th>
                     <th>에러</th>
                     <th class="text-end">본문</th>
@@ -952,7 +953,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
                 <tbody>
                   <template x-if="recentReviews.length === 0">
                     <tr>
-                      <td colspan="8" class="px-4 py-5 text-center text-secondary" x-text="recentLoading ? '최근 리뷰를 불러오는 중…' : '최근 리뷰 데이터가 없습니다.'"></td>
+                      <td colspan="9" class="px-4 py-5 text-center text-secondary" x-text="recentLoading ? '최근 리뷰를 불러오는 중…' : '최근 리뷰 데이터가 없습니다.'"></td>
                     </tr>
                   </template>
                 </tbody>
@@ -988,6 +989,10 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
                         </div>
                       </td>
                       <td>
+                        <div x-text="review.codexModel || '-'"></div>
+                        <div class="repo-subcopy" x-show="review.codexReasoningEffort" x-text="review.codexReasoningEffort"></div>
+                      </td>
+                      <td>
                         <code x-text="shortCommit(review.headCommitHash)"></code>
                       </td>
                       <td>
@@ -1009,7 +1014,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
                     </tr>
                     <template x-if="expandedReviewId === review.id">
                       <tr>
-                        <td colspan="8">
+                        <td colspan="9">
                           <template x-if="expandedLoading">
                             <div class="text-secondary">본문을 불러오는 중…</div>
                           </template>

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -99,8 +99,34 @@ describe("CodexService", () => {
       inputTokens: 1200,
       cachedInputTokens: 300,
       outputTokens: 80,
+      model: "o3",
+      reasoningEffort: null,
     });
     expect(rmSpy).toHaveBeenCalled();
+  });
+
+  // 토큰 통계를 모델에 귀속하려면 결과가 argv와 같은 값을 실어야 한다. 둘이 갈라지면
+  // 대시보드가 A 모델 수치를 B 모델 것으로 보고하게 된다.
+  it("reports the same model and reasoning effort it passed to the CLI", async () => {
+    const child = createMockChild();
+    spawnSpy.mockReturnValue(child);
+    readFileSpy.mockResolvedValue("out");
+
+    const promise = createService({
+      "codex.model": "gpt-6-astra",
+      "codex.reasoningEffort": "high",
+    }).executeCodex("/work", "main", "review this");
+
+    child.stdout.emit("data", makeTurnCompleted(10, 5, 1) + "\n");
+    child.emit("close", 0, null);
+
+    const result = await promise;
+    const args = spawnSpy.mock.calls[0][1] as string[];
+
+    expect(result.model).toBe(args[args.indexOf("--model") + 1]);
+    expect(result.model).toBe("gpt-6-astra");
+    expect(result.reasoningEffort).toBe("high");
+    expect(args).toContain('model_reasoning_effort="high"');
   });
 
   it.each([

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -235,6 +235,8 @@ export class CodexService {
         inputTokens: result.usage.inputTokens,
         cachedInputTokens: result.usage.cachedInputTokens,
         outputTokens: result.usage.outputTokens,
+        model: this.model,
+        reasoningEffort: this.reasoningEffort || null,
       };
     } finally {
       rm(outputFile, { force: true }).catch((err) => {

--- a/src/codex/interfaces/codex.interfaces.ts
+++ b/src/codex/interfaces/codex.interfaces.ts
@@ -6,4 +6,8 @@ export interface ICodexReviewResult {
   readonly inputTokens: number | null;
   readonly cachedInputTokens: number | null;
   readonly outputTokens: number | null;
+  /** 이 실행에 실제로 넘긴 --model 값 */
+  readonly model: string;
+  /** 넘긴 model_reasoning_effort 값. 미설정이면 null */
+  readonly reasoningEffort: string | null;
 }

--- a/src/database/migrations/1788566400000-add-review-run-model-metadata.spec.ts
+++ b/src/database/migrations/1788566400000-add-review-run-model-metadata.spec.ts
@@ -1,0 +1,40 @@
+import { QueryRunner } from "typeorm";
+import { AddReviewRunModelMetadata1788566400000 } from "./1788566400000-add-review-run-model-metadata";
+
+describe("AddReviewRunModelMetadata1788566400000", () => {
+  const queryRunner = {
+    query: jest.fn(),
+  } as unknown as QueryRunner;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("adds model attribution columns", async () => {
+    const migration = new AddReviewRunModelMetadata1788566400000();
+
+    await migration.up(queryRunner);
+
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining("ADD COLUMN codexModel varchar(64) NULL"),
+    );
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "ADD COLUMN codexReasoningEffort varchar(16) NULL",
+      ),
+    );
+  });
+
+  it("drops model attribution columns in reverse order", async () => {
+    const migration = new AddReviewRunModelMetadata1788566400000();
+
+    await migration.down(queryRunner);
+
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining("DROP COLUMN codexReasoningEffort"),
+    );
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining("DROP COLUMN codexModel"),
+    );
+  });
+});

--- a/src/database/migrations/1788566400000-add-review-run-model-metadata.ts
+++ b/src/database/migrations/1788566400000-add-review-run-model-metadata.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddReviewRunModelMetadata1788566400000
+  implements MigrationInterface
+{
+  name = "AddReviewRunModelMetadata1788566400000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE review_runs
+        ADD COLUMN codexModel varchar(64) NULL,
+        ADD COLUMN codexReasoningEffort varchar(16) NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE review_runs
+        DROP COLUMN codexReasoningEffort,
+        DROP COLUMN codexModel
+    `);
+  }
+}

--- a/src/entities/review-run.entity.ts
+++ b/src/entities/review-run.entity.ts
@@ -80,6 +80,14 @@ export class ReviewRunEntity extends BaseTableEntity {
   @Column({ type: "int", nullable: true })
   outputTokens: number;
 
+  // 토큰·소요 통계를 어떤 모델 설정으로 얻었는지 귀속하기 위한 값. codex는 지원하지
+  // 않는 모델을 받으면 400으로 실패하므로, 완주한 run의 이 값은 실제 사용 설정과 같다.
+  @Column({ type: "varchar", length: 64, nullable: true })
+  codexModel: string;
+
+  @Column({ type: "varchar", length: 16, nullable: true })
+  codexReasoningEffort: string;
+
   @Column({ type: "text", nullable: true })
   errorMessage: string;
 }

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -174,6 +174,8 @@ export class ReviewProcessor extends WorkerHost {
             inputTokens: failedCodexResult?.inputTokens ?? undefined,
             cachedInputTokens: failedCodexResult?.cachedInputTokens ?? undefined,
             outputTokens: failedCodexResult?.outputTokens ?? undefined,
+            codexModel: failedCodexResult?.model,
+            codexReasoningEffort: failedCodexResult?.reasoningEffort ?? undefined,
             errorMessage: error.message.substring(0, 2000),
           },
         );
@@ -522,6 +524,8 @@ export class ReviewProcessor extends WorkerHost {
         inputTokens: codexResult.inputTokens ?? undefined,
         cachedInputTokens: codexResult.cachedInputTokens ?? undefined,
         outputTokens: codexResult.outputTokens ?? undefined,
+        codexModel: codexResult.model,
+        codexReasoningEffort: codexResult.reasoningEffort ?? undefined,
       },
     );
 

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -26,6 +26,8 @@ export interface IRecentReview {
   readonly outputTokens: number | null;
   readonly durationMs: number | null;
   readonly totalDurationMs: number | null;
+  readonly codexModel: string | null;
+  readonly codexReasoningEffort: string | null;
   readonly createdAt: Date;
 }
 
@@ -207,6 +209,8 @@ export class ReviewService {
         | "inputTokens"
         | "cachedInputTokens"
         | "outputTokens"
+        | "codexModel"
+        | "codexReasoningEffort"
         | "errorMessage"
       >
     >,
@@ -265,6 +269,8 @@ export class ReviewService {
       outputTokens: toNullableNumber(row.outputTokens),
       durationMs: toNullableNumber(row.durationMs),
       totalDurationMs: toNullableNumber(row.totalDurationMs),
+      codexModel: row.codexModel ?? null,
+      codexReasoningEffort: row.codexReasoningEffort ?? null,
       createdAt: new Date(row.createdAt),
     };
   }


### PR DESCRIPTION
## 왜

`review_runs`에 토큰·소요는 있는데 **모델이 없다.** 오늘 프로덕션을 `gpt-5.6-sol` → `gpt-6-astra`로 전환했는데, 이전/이후 데이터를 가르는 근거가 **배포 시각 하나뿐**이다. 롤백하거나 A/B를 돌리면 귀속이 깨진다.

## 왜 출력 파싱이 아니라 config인가

codex 0.153.2의 `--json`이 내보내는 이벤트는 `thread.started`(thread_id만) / `turn.started` / `item.completed` / `turn.completed`(usage만) 넷뿐이고 **어디에도 모델이 없다.** 모델은 사람이 읽는 배너에만 찍히고 `--json`에서는 사라진다 (인스턴스에서 실측).

대신 `CodexService`가 argv에 넣은 값을 결과에 실었다. 이게 정확한 이유:

- 미지원 모델 → `400 invalid_request_error: The '...' model is not supported when using Codex with a ChatGPT account.` (실측)
- capacity 초과 → `CAPACITY_ERROR_MESSAGE` 에러 경로

즉 **조용한 폴백이 없다.** 완주한 run의 기록값 = 실제 사용값.

## 변경

- `ICodexReviewResult`에 `model` / `reasoningEffort` 추가 — `CodexService`가 이미 필드로 들고 있어 반환부 2줄
- `review_runs`에 `codexModel` varchar(64) / `codexReasoningEffort` varchar(16), 마이그레이션은 `AddReviewRunUsageMetrics` 선례 형식
- `updateStatus` Pick, `IRecentReview`, `toRecentReview` 매핑
- 완료 경로 **및 실패 경로** 둘 다 — `review.processor.ts:175`가 실패 run에도 토큰을 기록하고 있어 빠뜨리면 같은 공백이 남는다
- 대시보드 최근 리뷰 표에 "모델" 컬럼 (colspan 8 → 9)

## 검증

`pnpm build` / `pnpm lint` / `pnpm test --runInBand` → **18 suites, 250 tests 통과**

새 테스트는 argv의 `--model` 다음 값과 결과를 대조한다. 둘이 갈라지면 대시보드가 A 모델 수치를 B 모델 것으로 보고하므로 그 불일치가 실패 조건이다. (변경 전 상태에서는 `result.model`이 없어 타입 에러로 RED)

## 배포 시 주의

프로덕션은 `DB_SYNCHRONIZE=true`이고 `migrationsRun`이 없다. 마이그레이션 파일은 Helm 경로용이고, **EC2에서는 새 이미지 부팅 중 TypeORM이 `ALTER TABLE review_runs ADD COLUMN`을 실행한다.** 현재 944행이라 즉시 끝나지만 부팅 시 스키마가 바뀐다는 점은 알아야 한다. (선례 마이그레이션과 같은 패턴)

배포 후 `codexModel`이 채워진 첫 run부터가 Astra 측정 기준선이다. run 944 이하는 계속 시각 귀속으로만 남는다.