### PR TITLE
chore(ci): automate Codex CLI release rollout into the image

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -18,6 +18,7 @@
 | codex만 automerge | ✅ | `packageRules`의 `automerge: false → true`. `matchPackageNames: ["@openai/codex"]` 범위라 다른 의존성은 수동 유지. alpha 차단은 기존 `allowedVersions` 정규식이 이미 담당(`0.154.0-alpha.3` 탈락) |
 | 머지 → 이미지 발행 연결 | ✅ | `docker-publish.yml`이 `workflow_dispatch` 전용이라 bump를 머지해도 이미지가 안 나왔음. `push: branches: [main]` 추가. push 이벤트에서 `inputs.tag`는 `''`로 평가돼 태그 검증 스텝과 `type=raw` 룰이 함께 스킵되므로 Task 39의 `latest` 가드는 그대로 유효 |
 | automerge 안전 가드 | ✅ | CI가 이미지를 빌드하지 않아 codex bump PR의 green은 codex에 대해 아무것도 보증하지 않았음. `ci.yml`에 Dockerfile 핀을 추출해 설치·실행하고 `codex exec`가 `--model/--sandbox/--json/--output-last-message`를 여전히 노출하는지 확인하는 스텝 추가. Dockerfile `RUN`이 아니라 CI인 이유: **머지 전**에 돌아야 automerge를 막을 수 있고, 멀티아치 qemu 에뮬레이션 위험도 회피 |
+| `latest` 덮어쓰기 레이스 | ✅ | Codex 리뷰봇 P1 지적을 검증해 수용. `push: main` 추가로 도달 가능해진 결함 — publish run이 1분52초~3분12초 걸리는데 concurrency 가드가 없어, 3분 내 머지 2건이 겹치면 **오래된 run이 나중에 끝나며 `latest`를 덮어쓴다**. 프로덕션이 `:latest`를 pull하므로 구버전 배포로 이어짐. Renovate가 살아나면 밀린 19개+가 일괄 PR로 올라와 정확히 이 조건이 만들어진다. `concurrency: {group: docker-publish-${{ github.ref }}, cancel-in-progress: false}` 추가. `true`(취소) 대신 `false`(직렬화)인 이유는 중간 커밋의 `type=sha` 태그를 보존하기 위함 — tools-infra 런북이 `org.opencontainers.image.revision` 대조에 사용 |
 | 검증 | ⚠️ | `renovate-config-validator` 통과, 두 워크플로 YAML 파싱 확인, 로컬 codex 0.153.4로 4개 플래그 존재 확인. `pnpm lint/build/test`는 `src` 무변경이라 미실행 |
 | 배포(3번째 고리) | ⬜ | 프로덕션 EC2는 tools-infra `codex-code-review/compose.yaml`이 `:latest`를 소비하지만 자동 pull이 없음. tools-infra README 런북이 `org.opencontainers.image.revision` 수동 대조를 지시하고 있어 자동 pull은 그 절차와 충돌 — 별도 결정 필요 |
 

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,10 +1,25 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-09-06
+> 마지막 업데이트: 2026-09-07
 
 
 ## 진행 중/최근 작업
 
+
+### Task 40: Codex 릴리스 → 이미지 발행 자동화
+- **상태**: 코드 변경 완료 / Renovate 실행 확인 대기
+- **배경**: `@openai/codex` 신규 정식 릴리스가 나오면 그 버전으로 이미지를 자동 빌드·발행하고 싶다는 요구. 감지·발행·배포 3개 고리 중 앞 2개가 이 repo에 있다.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| Renovate 실행 여부 진단 | ⚠️ | 앱 설치 + repo 접근 권한은 확인됨(선생님 GitHub 설정 화면). 그런데 `renovate/*` 브랜치 0개, Dependency Dashboard 이슈 없음, 봇 PR 0건(#17~#41 전부 사람), HEAD check-run은 `github-actions` 하나뿐. `pnpm outdated` 결과 NestJS 11→12 major 포함 19개 이상이 밀려 있는데도 PR이 없음 → **이 repo에서 완료된 run이 한 번도 없음**. 원인은 developer.mend.io job log에서만 보이며 미확인 |
+| 설정 파일 결함 배제 | ✅ | `renovate-config-validator` 통과. 즉 zero-PR 원인은 설정이 아님 |
+| `fileMatch` → `managerFilePatterns` | ✅ | validator가 출력한 마이그레이션 형태 그대로 적용(`"/^Dockerfile$/"` — 신규 옵션은 regex를 슬래시로 감싸야 glob으로 오해되지 않음). 기존 `fileMatch`도 자동 마이그레이션되므로 고장은 아니었고 legacy 제거 목적 |
+| codex만 automerge | ✅ | `packageRules`의 `automerge: false → true`. `matchPackageNames: ["@openai/codex"]` 범위라 다른 의존성은 수동 유지. alpha 차단은 기존 `allowedVersions` 정규식이 이미 담당(`0.154.0-alpha.3` 탈락) |
+| 머지 → 이미지 발행 연결 | ✅ | `docker-publish.yml`이 `workflow_dispatch` 전용이라 bump를 머지해도 이미지가 안 나왔음. `push: branches: [main]` 추가. push 이벤트에서 `inputs.tag`는 `''`로 평가돼 태그 검증 스텝과 `type=raw` 룰이 함께 스킵되므로 Task 39의 `latest` 가드는 그대로 유효 |
+| automerge 안전 가드 | ✅ | CI가 이미지를 빌드하지 않아 codex bump PR의 green은 codex에 대해 아무것도 보증하지 않았음. `ci.yml`에 Dockerfile 핀을 추출해 설치·실행하고 `codex exec`가 `--model/--sandbox/--json/--output-last-message`를 여전히 노출하는지 확인하는 스텝 추가. Dockerfile `RUN`이 아니라 CI인 이유: **머지 전**에 돌아야 automerge를 막을 수 있고, 멀티아치 qemu 에뮬레이션 위험도 회피 |
+| 검증 | ⚠️ | `renovate-config-validator` 통과, 두 워크플로 YAML 파싱 확인, 로컬 codex 0.153.4로 4개 플래그 존재 확인. `pnpm lint/build/test`는 `src` 무변경이라 미실행 |
+| 배포(3번째 고리) | ⬜ | 프로덕션 EC2는 tools-infra `codex-code-review/compose.yaml`이 `:latest`를 소비하지만 자동 pull이 없음. tools-infra README 런북이 `org.opencontainers.image.revision` 수동 대조를 지시하고 있어 자동 pull은 그 절차와 충돌 — 별도 결정 필요 |
 
 ### Task 39: 사용하지 않는 Helm 차트 제거 + latest 태그 하드닝
 - **상태**: PR 제출

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,18 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      # Gates the automerged Renovate bump of the Dockerfile pin: CI never
+      # builds the image, so a Codex CLI that fails to run would otherwise
+      # reach main unverified and only break the publish job afterwards.
+      - name: Smoke-test pinned Codex CLI
+        run: |
+          version=$(sed -n 's|.*@openai/codex@\([0-9.]*\).*|\1|p' Dockerfile)
+          test -n "$version"
+          npm install -g "@openai/codex@$version"
+          codex --version
+          # The flags src/codex/codex.service.ts:45-62 builds its argv from.
+          for flag in --model --sandbox --json --output-last-message; do
+            codex exec --help | grep -q -- "$flag" || {
+              echo "::error::codex exec dropped $flag"; exit 1; }
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,8 @@
 name: Docker Publish
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,14 @@ on:
         required: false
         type: string
 
+# Serialize rather than cancel: the metadata step assigns a mutable `latest`,
+# so an older run finishing last would silently replace the newer image that
+# production pulls. Queueing keeps newest-wins while still publishing every
+# type=sha tag, which the deploy runbook checks via the revision label.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^Dockerfile$"],
+      "managerFilePatterns": ["/^Dockerfile$/"],
       "matchStrings": [
         "# renovate: datasource=npm depName=@openai/codex\\nRUN npm install -g @openai/codex@(?<currentValue>[\\d.]+)"
       ],
@@ -16,7 +16,7 @@
     {
       "matchPackageNames": ["@openai/codex"],
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/",
-      "automerge": false
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## What

Wires the two links that live in this repo so a new **stable** `@openai/codex` release reaches the published image without manual steps.

| File | Change |
|------|--------|
| `renovate.json` | `automerge: false → true`, scoped to `@openai/codex` only |
| `renovate.json` | deprecated `fileMatch` → `managerFilePatterns` |
| `docker-publish.yml` | add `push: branches: [main]` |
| `ci.yml` | smoke-test the pinned Codex CLI |

## Why each piece

**`docker-publish.yml` was `workflow_dispatch`-only** — a merged version bump produced no image at all. This was the actually-broken link. On `push` events `inputs.tag` evaluates to `''`, so both the tag validation step and the `type=raw` tag rule skip, leaving the `latest`-tag guards from #41 intact.

**The smoke test gates the automerge.** CI never builds the image, so a green run on a bump PR said nothing about Codex. It runs in CI rather than as a Dockerfile `RUN` for two reasons: the check has to happen *pre-merge* to be able to block automerge, and it avoids emulating the binary under qemu for the arm64 leg of the multi-arch build. It checks the binary executes *and* that `codex exec` still exposes the flags `src/codex/codex.service.ts:45-62` builds its argv from — a removed flag is the realistic breakage, and `--version` alone would not catch it.

**Prerelease filtering needed no work.** The existing `allowedVersions: "/^\\d+\\.\\d+\\.\\d+$/"` already drops `0.154.0-alpha.3`.

**`fileMatch` migration** uses the exact form `renovate-config-validator` emits — the new option needs the regex slash-wrapped (`"/^Dockerfile$/"`) or it is read as a glob. The old key auto-migrates, so this was not a defect.

## ⚠️ This does not make the automation live

Renovate is installed and has access to this repo, but **has never completed a run here**:

- no `renovate/*` branch on origin
- no Dependency Dashboard issue
- no bot PR across #17–#41
- `pnpm outdated` shows 19+ stale deps (NestJS 11→12 major included) with zero bump PRs

`renovate-config-validator` passes, so the cause is at the run level, not the config. It is only visible in the Mend job log. Leading hypothesis (estimate, not observation): repo access was granted recently and the first run has not happened yet.

## Out of scope

Production EC2 rollout. tools-infra `codex-code-review/compose.yaml` consumes `:latest` but does not auto-pull, and its runbook prescribes a manual `org.opencontainers.image.revision` check that an auto-pull would defeat.

## Verification

- `renovate-config-validator` passes
- both workflow YAMLs parse; triggers confirmed
- version-extraction `sed` returns `0.153.2` from the current Dockerfile
- all four `codex exec` flags confirmed present against local codex 0.153.4
- `pnpm lint/build/test` **not run** — no `src` changes

Also note: `push: main` publishes without waiting for CI. With no branch protection, a direct push to main that fails tests still overwrites `latest`. Not a regression (manual dispatch never gated on tests either), but the frequency goes up. The Renovate path itself is gated by PR CI.