### PR TITLE
fix(review): reply to the summary with findings whose inline post failed

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -6,6 +6,27 @@
 ## 진행 중/최근 작업
 
 
+### Task 42: 인라인 코멘트 부분 실패 복구 (issue #29)
+- **상태**: PR 제출 / 리뷰 대기 (브랜치 `fix/issue-29-surface-inline-failures`)
+- **배경**: `postInlineComments`의 개별 실패가 `logger.warn`으로만 남고, 폴백은 `postedCount === 0`(**전부** 실패)일 때만 돌았다. 그래서 10건 중 9건이 실패해도 런은 COMPLETED로 기록되고 사용자에게는 요약 코멘트만 보이며 지적 9건은 로그에만 남았다(대시보드상으로도 정상 완료). 리베이스·force push 후 finding의 라인이 diff hunk 범위를 벗어나 Bitbucket이 거부하는 경우에 실제로 발생한다. PR #25 적대적 리뷰(codex CLI) P2이고 PR #25 이전부터 있던 동작.
+- **왜 이 방식인가**: 이슈 본문의 "실패한 지적을 요약 코멘트 본문에 접어 넣는다"를 문자 그대로 하지 않았다. ① `BitbucketService`는 POST 전용이라(`postWithAuthFallback`이 `method: "POST"` 고정) 이미 게시된 요약 본문을 사후 편집할 수 없고 엔드포인트 신설은 범위 밖이다 ② 요약을 **먼저** 게시해야 한다 — 그 ID가 게시 증거(`resultCommentId`)이고 인라인 게시 전에 저장된다 ③ 순서를 뒤집으면(인라인 먼저 → 요약 나중) 요약 게시가 실패할 때 인라인은 이미 게시됐는데 `resultCommentId`가 null인 FAILED가 남고, 재멘션 시 `existsByIdempotencyKey`가 "게시 증거 없는 FAILED"로 보고 행을 삭제해 **인라인 코멘트가 중복 게시**된다(Task 41이 의존하는 #27/PR #31의 불변식). → 기존 `replyToComment`로 **요약 코멘트의 답글**을 다는 방식이 본문 의도("요약에 붙는다", "정보는 전달된다", "상태 모델을 안 건드린다")를 신규 API 없이 가장 가깝게 충족한다. 독립 코멘트와 달리 재실행으로 요약이 여럿 쌓여도 어느 런의 누락분인지 모호하지 않다.
+- **load-bearing 전제**: 복구 답글 게시 실패를 실패 범위와 무관하게 **균일하게 던지는** 것이 안전한 근거는 단 하나 — 요약 ID가 이미 `resultCommentId`(로컬 변수 + DB)에 남아 있어 `claimFailure`가 FAILED를 써도 행이 삭제되지 않는다는 것이다. 요약/인라인 게시 순서를 바꾸거나 `onResultCommentPublished` 호출 시점을 옮기면 이 전제가 깨지고 균일 throw가 중복 게시로 이어진다.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| 폴백 조건 일반화 | ✅ | `postedCount === 0` → `failedItems.length > 0`. 카운터 대신 실패한 finding 자체를 모아 복구 본문에 **실패분만** 담는다. 기존 per-item `logger.warn`과 `Inline comments posted: X/Y` 로그는 유지 |
+| `formatFindingsForGeneralComment` 추가 | ✅ | `formatInlineComment`은 `item.path`를 **전혀** emit하지 않고 `📍 L{start}-L{end}`도 `start !== end`일 때만 넣는다 — 인라인 코멘트는 Bitbucket이 위치를 앵커링하므로 본문에서 중복이기 때문이다. 그대로 일반 코멘트로 옮기면 **단일 라인 지적은 위치 정보가 완전히 사라진다**. 그래서 항목마다 `` ### `path` L{라인} `` 헤딩을 붙이는 전용 래퍼를 추가하고 `formatInlineComment` 자체는 수정하지 않았다(실제 인라인 본문이 계속 그것을 쓴다). 항목 구분자는 기존 폴백과 같은 `"\n\n---\n\n"` |
+| 복구 코멘트를 요약 답글로 | ✅ | `createComment`(독립 코멘트) → `replyToComment({ parentCommentId: summaryComment.id })`. 요약 ID는 `publishUnifiedResults`에서 `postInlineComments`로 인자로 넘긴다 |
+| 게시 증거 비오염 | ✅ | 복구 코멘트에는 `onResultCommentPublished`/`updateResultCommentId`를 **호출하지 않는다** — `resultCommentId`는 요약 코멘트 ID로 유지되어야 한다. 코드에 불변식 주석으로 명시 |
+| 실패 처리: 균일 throw | ✅ | 복구 게시 실패는 삼키지 않는다. 부분 실패에서만 `logger.error`로 삼키면 이 이슈가 지적한 버그(지적 유실 + COMPLETED + 대시보드 정상)를 그대로 남기고, 401일 때 `authenticationFailureStage` 분기와 카운터도 우회한다. 전부 실패 경로가 이미 "요약은 게시, 지적은 유실 → FAILED"를 선례로 갖고 있어 균일 처리가 선례와 일관된다 |
+| 회귀 테스트 | ✅ | 프로세서 7건 + 포매터 2건 추가. 프로세서 7건 중 **6건을 변경 전 코드에서 RED 확인**(`review.processor.ts`만 원본으로 되돌려 실행). 계획서가 RED로 표시한 4건 중 "루프가 끝까지 돈다"·"`updateResultCommentId` 정확히 1회"는 **그 자체로는 변경 전에도 GREEN**이다(현재 루프도 실패를 지나 계속 돌고, 부분 실패 시 `updateResultCommentId`는 1회다) — 두 테스트에 "복구 답글이 게시됐다"는 전제 어서션을 함께 넣어서 RED가 됐다. 유일한 GREEN 특성화는 "전부 성공 시 복구 답글 없음"(회귀 가드). 기존 스펙에 옛 `createComment` 폴백을 단정한 테스트는 **없었다**(`"All inline comments failed"`/`"코드 리뷰 상세"` 스펙 내 0건) — 갱신할 어서션 없음 |
+| 테스트 강화 (적대적 리뷰 수용) | ✅ | 복구 게시 실패 테스트 2건이 `rejects.toThrow("...메시지")`만 단정하고 있었다 — 평범한 `Error`도 그 단정을 통과하는데 안전성 논거는 **`UnrecoverableError`**에 달려 있다(평범한 Error가 올라가면 BullMQ가 잡을 재시도해 요약·인라인이 중복 게시된다). `rejects.toBeInstanceOf(UnrecoverableError)`를 추가하고 **뮤테이션으로 load-bearing임을 확인**했다: `throw new UnrecoverableError(error.message)` → `throw err`로 바꾸면 두 테스트가 `Expected constructor: UnrecoverableError / Received constructor: Error`로 실패한다(메시지 단정만으로는 통과했을 회귀). 더불어 균일 throw의 사용자 관점 귀결(`replyToComment({ parentCommentId: 999 })`로 나가는 `❌ Code Review 실패` 통보)을 두 테스트에 단정했다. 프로덕션 코드 변경 없음 |
+| 빌드/린트/테스트 | ✅ | `npx nest build`, `npx eslint "{src,test}/**/*.ts"`(--fix 없이 경고 0), `npx jest --runInBand` 성공 (18 suites, 271 tests — 베이스라인 262 + 9) |
+| 커버리지 | ✅ | `npx jest --coverage --runInBand`: statement 91.08%, branch 81.44%, function 83.24%, line 91.17% (베이스라인 90.64/81.17/82.58/90.69에서 4개 지표 모두 상승). 신규 코드에 미커버 라인 없음 — `review.processor.ts`·`review.formatter.ts`의 미커버 라인은 전부 기존 코드 |
+| 보안 체크리스트 | ✅ | 스키마·시크릿·외부 입력 검증 변경 없음. 복구 본문은 이미 인라인 코멘트로 나가던 것과 같은 Codex 산출 텍스트이고, 새 로그는 이미 기록 중인 실패 건수만 남긴다 |
+| 범위 밖 | ⚠️ | ① `filterFindingsToReviewDiff`는 **path만** 검사한다 — 이슈가 언급한 근본 원인(리베이스 후 라인이 hunk 범위를 벗어남)은 이 필터를 통과해 Bitbucket에서 거부된다. hunk 범위 사전 검사가 진짜 예방책이지만 이 이슈 범위가 아니다 ② 코멘트 본문 크기 상한 가드가 어디에도 없다. 기존 결함이고 회귀는 아니지만, 폴백이 더 자주 도는 만큼 노출은 커진다 |
+
+
 ### Task 41: 대체된 리뷰의 게시 차단 (issue #26)
 - **상태**: PR #51 제출 / 리뷰 대기
 - **배경**: `supersedeActivePrReviews()`가 오래된 런을 SUPERSEDED로 바꿔도 그 런이 계속 Bitbucket에 게시했다. 원인은 상태 전이가 **무조건 UPDATE**였고 게시 권한이 프로세스 메모리(`publishStarted`)에 있었다는 것. 구체적으로 ① `idempotencyKey`에 head commit이 들어가 새 커밋 웹훅이 실행 중 잡의 `jobId`를 찾지 못해 제거하지 못함 ② `attemptsMade > 0` 사전 조회는 Codex 실행(수 분) 앞의 시점 스냅샷이라 TOCTOU 창이 분 단위 ③ 워커 SIGKILL 후 stalled 복구는 `attemptsMade`를 늘리지 않아 사전 조회와 메모리 플래그를 모두 우회 ④ `prepareWorkspace()`가 PREPARING을 무조건 써서 SUPERSEDED 행을 되살림 ⑤ 실패 경로도 무방비라 대체된 런이 뒤늦게 실패하면 SUPERSEDED를 FAILED로 덮어쓰고(실패 집계 오염) 낡은 커밋에 실패 댓글을 달았음.

--- a/src/queue/review.formatter.ts
+++ b/src/queue/review.formatter.ts
@@ -45,6 +45,26 @@ export function formatInlineComment(item: IReviewItem): string {
   return parts.join("\n");
 }
 
+/**
+ * 인라인 게시가 실패한 finding을 일반 코멘트로 옮길 때 쓰는 포매터.
+ *
+ * `formatInlineComment`은 `path`를 전혀 emit하지 않고 라인 범위도 `start !== end`일 때만 넣는다
+ * — 인라인 코멘트는 Bitbucket이 위치를 앵커링하므로 본문에 위치가 중복이기 때문이다. 하지만
+ * 일반 코멘트로 옮기면 그 위치 정보가 사라진다(단일 라인 지적은 위치가 아예 없어진다).
+ * 그래서 여기서 `path` + 라인 범위 헤딩을 항목마다 앞에 붙인다.
+ */
+export function formatFindingsForGeneralComment(
+  items: ReadonlyArray<IReviewItem>,
+): string {
+  return items
+    .map((item) => {
+      const { start, end } = item.lineRange;
+      const lineLabel = start === end ? `L${start}` : `L${start}-L${end}`;
+      return `### \`${item.path}\` ${lineLabel}\n\n${formatInlineComment(item)}`;
+    })
+    .join("\n\n---\n\n");
+}
+
 /** 리뷰 항목에서 severity별 건수 요약 테이블 생성 */
 export function buildSummaryTable(
   items: ReadonlyArray<IReviewItem>,

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -3,6 +3,7 @@ import {
   parseReviewItems,
   parseUnifiedReviewJson,
   formatInlineComment,
+  formatFindingsForGeneralComment,
   buildSummaryTable,
   buildVerdictBadge,
   normalizeSummaryMarkdown,
@@ -623,6 +624,57 @@ describe("review.formatter", () => {
       const result = formatInlineComment(item);
 
       expect(result).not.toContain("****"); // empty bold
+    });
+  });
+
+  describe("formatFindingsForGeneralComment", () => {
+    // 인라인 코멘트에서는 Bitbucket이 위치를 앵커링하므로 formatInlineComment가 path를
+    // 생략하고 라인도 start !== end일 때만 넣는다. 일반 코멘트로 옮기면 그 위치가 사라지므로
+    // 이 래퍼가 항목마다 path + 라인 헤딩을 반드시 붙여야 한다.
+    it("should carry the location of a single-line finding that formatInlineComment omits", () => {
+      const item: IReviewItem = {
+        title: "단일 라인",
+        path: "src/app.ts",
+        lineRange: { start: 10, end: 10 },
+        severity: "suggestion",
+        description: "Consider extracting constant",
+        reason: "Improves readability",
+      };
+
+      expect(formatInlineComment(item)).not.toContain("src/app.ts");
+
+      const result = formatFindingsForGeneralComment([item]);
+
+      expect(result).toContain("src/app.ts");
+      expect(result).toContain("L10");
+      expect(result).toContain("Consider extracting constant");
+    });
+
+    it("should render a line range and separate multiple findings", () => {
+      const result = formatFindingsForGeneralComment([
+        {
+          title: "범위 지적",
+          path: "src/a.ts",
+          lineRange: { start: 40, end: 45 },
+          severity: "blocking",
+          description: "range issue",
+          reason: "range reason",
+        },
+        {
+          title: "단일 지적",
+          path: "src/b.ts",
+          lineRange: { start: 7, end: 7 },
+          severity: "recommended",
+          description: "single issue",
+          reason: "single reason",
+        },
+      ]);
+
+      expect(result).toContain("src/a.ts");
+      expect(result).toContain("L40-L45");
+      expect(result).toContain("src/b.ts");
+      expect(result).toContain("L7");
+      expect(result).toContain("\n\n---\n\n");
     });
   });
 
@@ -1315,6 +1367,277 @@ describe("ReviewProcessor publish results", () => {
       mockBitbucketService.createComment.mock.invocationCallOrder[0],
     ).toBeLessThan(persistOrder);
     expect(persistOrder).toBeLessThan(completedOrder);
+  });
+
+  describe("inline comment recovery", () => {
+    // 두 finding이 서로 다른 파일이어야 "실패분만 담겼다"를 path로 단정할 수 있다.
+    // 둘 다 filterFindingsToReviewDiff를 통과해야 하므로 diff에 두 파일 모두 필요하다.
+    const twoFileReviewDiff = [
+      "diff --git a/src/keep.ts b/src/keep.ts",
+      "+++ b/src/keep.ts",
+      "@@ -1,1 +1,1 @@",
+      "+kept line",
+      "diff --git a/src/lost.ts b/src/lost.ts",
+      "+++ b/src/lost.ts",
+      "@@ -30,1 +31,1 @@",
+      "+lost line",
+    ].join("\n");
+
+    // 실패하는 쪽을 단일 라인으로 둔다 — formatInlineComment은 start === end면 라인을
+    // 아예 emit하지 않으므로, 복구 본문의 "L31"은 신규 포매터만이 만들어낼 수 있다.
+    const findings: ReadonlyArray<IReviewItem> = [
+      {
+        title: "게시 성공",
+        path: "src/keep.ts",
+        lineRange: { start: 1, end: 1 },
+        severity: "recommended",
+        description: "인라인으로 잘 올라간 지적",
+        reason: "성공 사유",
+      },
+      {
+        title: "게시 실패",
+        path: "src/lost.ts",
+        lineRange: { start: 31, end: 31 },
+        severity: "blocking",
+        description: "인라인 게시가 거부된 지적",
+        reason: "실패 사유",
+      },
+    ];
+
+    const inlineRejection = (path: string): Error =>
+      new Error(
+        `Bitbucket inline comment API error 400: line for ${path} is outside the diff`,
+      );
+
+    function arrangeRun(): void {
+      mockWorkspaceService.prepareWorktree.mockResolvedValue({
+        worktreePath: "/worktree",
+        bareRepoPath: "/bare",
+      });
+      mockWorkspaceService.cleanupWorktree.mockResolvedValue(undefined);
+      mockWorkspaceService.createReviewDiff.mockResolvedValue({
+        diff: twoFileReviewDiff,
+        excludedChangedFiles: [],
+      });
+      mockCodexService.executeCodex.mockResolvedValue({
+        rawOutput: JSON.stringify({
+          summary: "ok",
+          verdict: "comment",
+          confidence: 90,
+          findings,
+        }),
+        exitCode: 0,
+        durationMs: 10,
+        inputTokens: null,
+        cachedInputTokens: null,
+        outputTokens: null,
+      });
+    }
+
+    it("replies to the summary comment with only the findings whose inline post failed", async () => {
+      arrangeRun();
+      mockBitbucketService.createInlineComment
+        .mockResolvedValueOnce({ id: 102 })
+        .mockRejectedValueOnce(inlineRejection("src/lost.ts"));
+
+      await processor.process({ data: baseJobData } as never);
+
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledTimes(1);
+      // 답글이어야 한다 — 재실행으로 요약이 여럿 쌓여도 어느 런의 누락분인지 모호해지지 않는다.
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentCommentId: 100,
+          body: expect.stringContaining("src/lost.ts"),
+        }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.stringContaining("L31") }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining("인라인 게시가 거부된 지적"),
+        }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.not.stringContaining("src/keep.ts"),
+        }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.not.stringContaining("인라인으로 잘 올라간 지적"),
+        }),
+      );
+      expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+        1,
+        "completed",
+        expect.anything(),
+      );
+    });
+
+    it("keeps posting the remaining inline comments after one is rejected", async () => {
+      arrangeRun();
+      mockBitbucketService.createInlineComment
+        .mockRejectedValueOnce(inlineRejection("src/keep.ts"))
+        .mockResolvedValueOnce({ id: 102 });
+
+      await processor.process({ data: baseJobData } as never);
+
+      expect(mockBitbucketService.createInlineComment).toHaveBeenCalledTimes(2);
+      expect(mockBitbucketService.createInlineComment).toHaveBeenCalledWith(
+        expect.objectContaining({ filePath: "src/keep.ts", line: 1 }),
+      );
+      expect(mockBitbucketService.createInlineComment).toHaveBeenCalledWith(
+        expect.objectContaining({ filePath: "src/lost.ts", line: 31 }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({ parentCommentId: 100 }),
+      );
+    });
+
+    it("keeps the summary comment as the sole publish evidence when a recovery reply is posted", async () => {
+      arrangeRun();
+      mockBitbucketService.createInlineComment
+        .mockResolvedValueOnce({ id: 102 })
+        .mockRejectedValueOnce(inlineRejection("src/lost.ts"));
+
+      await processor.process({ data: baseJobData } as never);
+
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({ parentCommentId: 100 }),
+      );
+      // 복구 답글(id 101)이 게시 증거를 덮어쓰면 행이 요약 코멘트를 가리키지 않게 된다.
+      expect(mockReviewService.updateResultCommentId).toHaveBeenCalledTimes(1);
+      expect(mockReviewService.updateResultCommentId).toHaveBeenCalledWith(
+        1,
+        100,
+      );
+    });
+
+    it("fails the run when the recovery reply is rejected after a partial inline failure", async () => {
+      arrangeRun();
+      mockBitbucketService.createInlineComment
+        .mockResolvedValueOnce({ id: 102 })
+        .mockRejectedValueOnce(inlineRejection("src/lost.ts"));
+      mockBitbucketService.replyToComment.mockRejectedValueOnce(
+        new Error("Bitbucket API error 500: recovery reply rejected"),
+      );
+
+      const processing = processor.process({ data: baseJobData } as never);
+
+      // 에러 **타입**이 load-bearing이다 — 평범한 Error가 올라가면 BullMQ가 잡을 재시도해
+      // 요약과 인라인 코멘트가 중복 게시된다. 메시지 단정만으로는 그 회귀를 잡을 수 없다.
+      await expect(processing).rejects.toBeInstanceOf(UnrecoverableError);
+      await expect(processing).rejects.toThrow(
+        "Bitbucket API error 500: recovery reply rejected",
+      );
+
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({ parentCommentId: 100 }),
+      );
+      expect(mockReviewService.updateStatus).not.toHaveBeenCalledWith(
+        1,
+        "completed",
+        expect.anything(),
+      );
+      // 균일하게 던져도 안전한 이유: 요약 ID가 FAILED와 함께 남아 행이 삭제되지 않는다
+      // (게시 증거 없는 FAILED는 existsByIdempotencyKey가 지워 중복 게시로 이어진다).
+      expect(mockReviewService.claimFailure).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ resultCommentId: 100 }),
+      );
+      // 균일 throw의 사용자 관점 귀결 — 런이 조용히 끝나지 않고 실패가 트리거 코멘트에 통보된다.
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentCommentId: 999,
+          body: expect.stringContaining("❌ Code Review 실패"),
+        }),
+      );
+    });
+
+    it("does not post a recovery reply when every inline comment succeeds", async () => {
+      arrangeRun();
+
+      await processor.process({ data: baseJobData } as never);
+
+      expect(mockBitbucketService.createInlineComment).toHaveBeenCalledTimes(2);
+      expect(mockBitbucketService.replyToComment).not.toHaveBeenCalled();
+      expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+        1,
+        "completed",
+        expect.anything(),
+      );
+    });
+
+    it("puts every finding in the recovery reply when all inline comments fail", async () => {
+      arrangeRun();
+      mockBitbucketService.createInlineComment
+        .mockRejectedValueOnce(inlineRejection("src/keep.ts"))
+        .mockRejectedValueOnce(inlineRejection("src/lost.ts"));
+
+      await processor.process({ data: baseJobData } as never);
+
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledTimes(1);
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentCommentId: 100,
+          body: expect.stringContaining("src/keep.ts"),
+        }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining("인라인으로 잘 올라간 지적"),
+        }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining("src/lost.ts"),
+        }),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining("인라인 게시가 거부된 지적"),
+        }),
+      );
+      // 요약 코멘트만 독립 코멘트로 남는다 — 복구분은 답글이므로 createComment가 늘지 않는다.
+      expect(mockBitbucketService.createComment).toHaveBeenCalledTimes(1);
+      expect(mockReviewService.updateStatus).toHaveBeenCalledWith(
+        1,
+        "completed",
+        expect.anything(),
+      );
+    });
+
+    it("fails the run when the recovery reply is rejected after every inline comment failed", async () => {
+      arrangeRun();
+      mockBitbucketService.createInlineComment
+        .mockRejectedValueOnce(inlineRejection("src/keep.ts"))
+        .mockRejectedValueOnce(inlineRejection("src/lost.ts"));
+      mockBitbucketService.replyToComment.mockRejectedValueOnce(
+        new Error("Bitbucket API error 503: recovery reply rejected"),
+      );
+
+      const processing = processor.process({ data: baseJobData } as never);
+
+      // 부분 실패와 동일한 계약이어야 한다 — 실패 범위가 재시도 가능성을 바꾸면
+      // 전부 실패한 런이 재시도되어 요약 코멘트가 중복 게시된다.
+      await expect(processing).rejects.toBeInstanceOf(UnrecoverableError);
+      await expect(processing).rejects.toThrow(
+        "Bitbucket API error 503: recovery reply rejected",
+      );
+
+      expect(mockReviewService.updateStatus).not.toHaveBeenCalledWith(
+        1,
+        "completed",
+        expect.anything(),
+      );
+      expect(mockBitbucketService.replyToComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentCommentId: 999,
+          body: expect.stringContaining("❌ Code Review 실패"),
+        }),
+      );
+    });
   });
 });
 

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -14,6 +14,7 @@ import { BitbucketService } from "../bitbucket/bitbucket.service";
 import { type IReviewItem, type IUnifiedReviewResult } from "./review.types";
 import {
   formatInlineComment,
+  formatFindingsForGeneralComment,
   buildSummaryTable,
   buildVerdictBadge,
   normalizeSummaryMarkdown,
@@ -442,7 +443,7 @@ export class ReviewProcessor extends WorkerHost {
 
     // Post inline comments
     if (findings.length > 0) {
-      await this.postInlineComments(data, findings);
+      await this.postInlineComments(data, findings, summaryComment.id);
     }
 
     return summaryComment.id;
@@ -466,12 +467,13 @@ export class ReviewProcessor extends WorkerHost {
     return comment.id;
   }
 
-  /** inline comments 개별 게시 (전체 실패 시 일반 댓글 fallback) */
+  /** inline comments 개별 게시 (실패분은 요약 코멘트 답글로 복구 게시) */
   private async postInlineComments(
     data: IReviewJobData,
     findings: ReadonlyArray<IReviewItem>,
+    summaryCommentId: number,
   ): Promise<void> {
-    let postedCount = 0;
+    const failedItems: IReviewItem[] = [];
     for (const item of findings) {
       try {
         const body = formatInlineComment(item);
@@ -483,30 +485,41 @@ export class ReviewProcessor extends WorkerHost {
           line: item.lineRange.end,
           body,
         });
-        postedCount++;
       } catch (err) {
         this.logger.warn(
           `Inline comment failed for ${item.path}:${item.lineRange.end}: ${(err as Error).message}`,
         );
+        failedItems.push(item);
       }
     }
     this.logger.log(
-      `Inline comments posted: ${postedCount}/${findings.length}`,
+      `Inline comments posted: ${findings.length - failedItems.length}/${findings.length}`,
     );
 
-    // If all inline comments failed, fallback to general comment
-    if (postedCount === 0) {
-      this.logger.warn("All inline comments failed, falling back to general comment");
-      const fallbackBody = findings
-        .map((f) => formatInlineComment(f))
-        .join("\n\n---\n\n");
-      await this.bitbucketService.createComment({
-        workspace: data.workspaceSlug,
-        repoSlug: data.repositorySlug,
-        pullRequestId: data.pullRequestId,
-        body: `## 🔍 코드 리뷰 상세\n\n${fallbackBody}`,
-      });
+    if (failedItems.length === 0) {
+      return;
     }
+
+    // 한 건이라도 인라인 게시가 실패하면 그 지적은 로그에만 남아 사용자에게서 유실된다.
+    // 실패분만 담아 요약 코멘트의 **답글**로 다시 올린다 — 재실행으로 요약이 여럿 쌓여도
+    // 어느 런의 누락분인지 모호하지 않다.
+    // 두 가지 비자명한 불변식:
+    //  1. 복구 코멘트는 `onResultCommentPublished`를 호출하지 않는다 — 게시 증거
+    //     (`resultCommentId`)는 요약 코멘트 ID로 유지되어야 한다.
+    //  2. 이 게시의 실패는 실패 범위와 무관하게 **의도적으로 치명적**이다(삼키지 않는다).
+    //     삼키면 "지적 유실 + 런 COMPLETED"라는 이 이슈의 버그가 그대로 남고, 401일 때
+    //     `authenticationFailureStage` 분기와 카운터도 우회한다. 요약 ID가 이미 저장돼
+    //     있으므로 FAILED가 기록돼도 행은 삭제되지 않아 중복 게시 위험은 없다.
+    this.logger.warn(
+      `${failedItems.length}/${findings.length} inline comments failed, replying to the summary comment with the missing findings`,
+    );
+    await this.bitbucketService.replyToComment({
+      workspace: data.workspaceSlug,
+      repoSlug: data.repositorySlug,
+      pullRequestId: data.pullRequestId,
+      parentCommentId: summaryCommentId,
+      body: `## 🔍 인라인 게시에 실패한 지적 ${failedItems.length}건\n\n인라인 코멘트 게시가 거부되어 아래로 옮겼습니다. 위치는 각 항목 헤딩을 참고하세요.\n\n${formatFindingsForGeneralComment(failedItems)}`,
+    });
   }
 
   private filterFindingsToReviewDiff(


### PR DESCRIPTION
Closes #29

## 문제

인라인 게시 루프는 개별 실패를 `logger.warn`으로만 남기고 계속 진행했고, 폴백은
`postedCount === 0`(**전부** 실패)일 때만 돌았다. 그래서 10건 중 9건이 실패해도:

- 런은 `COMPLETED`로 기록된다.
- 사용자에게는 요약 코멘트만 보이고, 누락된 지적 9건은 로그에만 남는다.
- 대시보드상으로도 정상 완료로 집계된다.

리베이스·force push 후 finding의 라인이 diff hunk 범위를 벗어나 Bitbucket이 거부하면 실제로 발생한다.
PR #25 적대적 리뷰 P2이고 PR #25 이전부터 있던 동작이다.

## 해결

폴백 조건을 **"전부 실패" → "일부라도 실패"** 로 일반화하고, **실패한 finding만** 담아
**요약 코멘트의 답글**로 올린다(`replyToComment`, `parentCommentId = summaryComment.id`).

### 계획 단계에서 발견한 것 — 그대로 옮기면 위치 정보가 사라진다

`formatInlineComment`(`src/queue/review.formatter.ts`)은 **`item.path`를 전혀 emit하지 않고**
`📍 L{start}-L{end}`도 `start !== end`일 때만 넣는다. 실제 인라인 코멘트는 Bitbucket이 위치를
앵커링하므로 본문의 위치가 중복이기 때문이다. 하지만 그대로 일반 코멘트로 옮기면 **단일 라인
지적은 위치가 아예 없어진다** — 기존 "전부 실패" 폴백도 같은 결함을 갖고 있었다.
이슈가 요구한 "**파일:라인** + 내용"을 만족시키기 위해 항목마다 `` ### `path` L{라인} `` 헤딩을
붙이는 전용 포매터 `formatFindingsForGeneralComment`를 추가했다.
`formatInlineComment` 자체는 수정하지 않았다 — 실제 인라인 본문이 계속 그것을 쓴다.

### 이슈 본문의 "요약 코멘트 본문에 접어 넣기"를 문자 그대로 하지 않은 이유

1. `BitbucketService`는 POST 전용이다(`postWithAuthFallback`이 `method: "POST"` 고정). 이미
   게시된 요약 본문을 사후 편집할 수 없고, 수정 엔드포인트 신설은 이 이슈 범위 밖이다.
2. 요약 코멘트는 **먼저** 게시돼야 한다 — 그 ID가 게시 증거(`resultCommentId`)이고 인라인 게시
   전에 저장된다(순서 전용 테스트가 이미 있다).
3. 순서를 뒤집으면(인라인 먼저 → 요약 나중) 요약 게시 실패 시 "인라인은 게시됐는데
   `resultCommentId`는 null인 FAILED"가 남고, 재멘션하면 `existsByIdempotencyKey`가 게시 증거 없는
   FAILED로 보고 행을 삭제해 **인라인 코멘트가 중복 게시**된다. 이 불변식은 #27/PR #31(`f4e9948`)이
   세웠고 PR #51이 그것에 의존한다.

→ **요약의 답글**이 본문 의도("요약에 붙는다", "정보는 전달된다", "상태 모델을 안 건드린다")를
신규 API 없이 가장 가깝게 충족한다. 재실행으로 요약이 여럿 쌓여도 어느 런의 누락분인지 모호하지 않다.

### load-bearing 전제

복구 게시 실패를 **균일하게 던지는** 것이 안전한 근거는 하나다 — 요약 ID가 이미
`resultCommentId`(로컬 변수는 DB 쓰기 **전에** 할당)에 남아 있어 `claimFailure`가 FAILED를 써도
행이 삭제되지 않는다는 것. 요약/인라인 순서나 `onResultCommentPublished` 호출 시점을 옮기면 이
전제가 깨지고 균일 throw가 중복 게시로 이어진다. 복구 코멘트는 `onResultCommentPublished`를
**호출하지 않는다**.

부분 실패에서만 삼키면 이 이슈가 지적한 버그(지적 유실 + COMPLETED + 대시보드 정상)를 그대로
남기고, 401일 때 `authenticationFailureStage` 분기와 카운터도 우회한다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npx jest --runInBand` | exit 0 — 18 suites, **271 tests** 통과 (베이스라인 262 + 9) |
| `npx nest build` | exit 0 |
| `npx eslint "{src,test}/**/*.ts"` (`--fix` 없이) | exit 0, 경고/에러 없음 |
| `npx jest --coverage --runInBand` | statement **91.08%**, branch **81.44%**, function **83.24%**, line **91.17%** (베이스라인 90.64/81.17/82.58/90.69에서 4개 지표 모두 상승) |

**RED 확인**: `review.processor.ts`만 원본으로 되돌려 실행 → 신규 프로세서 테스트 7건 중 **6건 실패**.
1건("전부 성공 시 복구 답글 없음")은 회귀 가드라 양쪽에서 통과하는 것이 정상이다.

**뮤테이션 확인**: 복구 실패 테스트 2건이 처음엔 메시지만 단정했다 — 평범한 `Error`도 통과하는데
안전성 논거는 `UnrecoverableError`에 달려 있다(평범한 Error면 BullMQ가 재시도해 중복 게시).
`throw new UnrecoverableError(error.message)` → `throw err`로 바꾸면 두 테스트가
`Expected constructor: UnrecoverableError / Received constructor: Error`로 실패한다.
메시지 단정만으로는 통과했을 회귀다.

**적대적 리뷰**: 신선한 컨텍스트(Fable 5, read-only)로 실행 — **blocking 0건**. 지적 2건(에러 타입
미고정, 실패 통보 미단정)을 수용해 테스트를 강화했고, 2건(공용 실패 통보 본문에 실패 목록 추가,
다중 라인 범위 라벨 중복 제거)은 각각 범위 확장·`formatInlineComment` 수정 필요를 이유로 기각했다.

## 이 PR 범위 밖 (관측 기록, 별도 이슈 미생성)

1. `filterFindingsToReviewDiff`는 **path만** 검사한다. 이슈가 언급한 근본 원인(리베이스 후 라인이
   hunk 범위를 벗어남)은 이 필터를 통과해 Bitbucket에서 거부된다. hunk 범위 사전 검사가 진짜
   예방책이지만 이 이슈는 "실패를 삼키지 않는다"까지만 다룬다.
2. 코멘트 본문 크기 상한 가드가 어디에도 없다. 기존 결함이고 회귀는 아니지만, 폴백이 더 자주 도는
   만큼 노출이 커진다. 복구 본문이 상한을 넘으면 매번 실패해 균일 throw가 결정적 실패가 된다.
