### PR TITLE
feat: default reviews to gpt-5.6-sol and allow --model override in @codex comments

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,10 +1,19 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-09-07
+> 마지막 업데이트: 2026-09-08
 
 
 ## 진행 중/최근 작업
 
+
+### Task 43: 기본 모델 `gpt-5.6-sol` 환원 + 댓글 모델 오버라이드
+- **상태**: 구현·검증 완료 / 커밋 승인 대기
+- **배경**: 선생님 요청 — 기본 모델을 `gpt-5.6-sol`로 환원하고, 대신 PR 댓글 한 줄로 이번 리뷰에만 쓸 모델을 지정할 수 있게 한다.
+- **변경**: `DEFAULTS.CODEX_MODEL`, `.env.example`, `docker-compose.yml`, README, 설정/웹훅/검증 테스트를 `gpt-5.6-sol`로 환원. `TriggerService.parseModelOverride`가 `@codex --model:<name>`(`=`·공백 구분자 포함)을 추출해 `IReviewJobData.model`로 실려 `executeCodex(…, model)`까지 흐른다.
+- **보안**: 값이 `spawn` argv의 `--model` 뒤에 그대로 들어가므로 `[A-Za-z0-9][\w.-]*`로 제한한다 — 선두 `-`를 막아 임의 codex 플래그 주입을 차단한다. allowlist는 두지 않았다(Task 28 결정 유지).
+- **정합성**: 진행 중 코멘트(`⏳ … Model: …`)와 DB `codexModel` 모두 오버라이드 값을 쓴다. 둘 중 하나만 반영하면 사용자에게 보이는 모델과 실제 실행 모델이 갈라진다.
+- **검증**: `pnpm build`, `pnpm lint`(경고 0), `pnpm test --runInBand` 성공 (18 suites, 280 tests — 베이스라인 271 + 9). `pnpm test:cov`: statement 91.11%, branch 82.38%, function 83.33%, line 91.19%.
+- **범위 밖**: ① `CODEX_FORCE_REGEX`는 `--force`가 `@codex` 바로 뒤일 것을 요구하므로 `@codex --model:x --force`는 force로 잡히지 않는다(순서 무관하게 하려면 정규식 완화 필요) ② reasoning effort는 오버라이드 대상이 아니다 — 모델을 바꿔도 `CODEX_REASONING_EFFORT`가 그대로 적용된다.
 
 ### Task 42: 인라인 코멘트 부분 실패 복구 (issue #29)
 - **상태**: PR 제출 / 리뷰 대기 (브랜치 `fix/issue-29-surface-inline-failures`)
@@ -90,6 +99,7 @@
 - **잔존 문자열 조사**: 이전 모델 ID는 과거 Task 27/28, 2026-07-10 설계/계획 문서, GPT-5.6 명시적 모델 전달 테스트에만 의도적으로 유지.
 - **검증**: `pnpm build`, `pnpm lint`, `pnpm test --runInBand`, `pnpm test:cov --runInBand` 성공 (17 suites, 247 tests). 커버리지 statement 89.96%, branch 80.69%, function 81.6%, line 89.97%. Helm lint 및 ConfigMap 렌더링에서 새 모델 확인.
 - **보안/범위**: 신규 시크릿·외부 입력·에러 노출 변경 없음. 모델 allowlist 미추가, reasoning effort 및 Dockerfile `@openai/codex@0.153.2` 핀 유지. 인스턴스·배포 미접촉.
+- **후속**: 기본값은 Task 43에서 `gpt-5.6-sol`로 환원됨 (댓글 `--model` 오버라이드로 대체).
 - **머지 조건**: teal-tapir의 ChatGPT 계정 인증 실호출 접근성·할당량 확인 결과 대기. 프로덕션 모델은 tools-infra `codex-code-review/fetch-env.sh`의 `CODEX_MODEL`이 결정하므로 이 PR만으로 변경되지 않음.
 
 ### Task 37: BullMQ major 대비 colonless review jobId

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -7,7 +7,7 @@
 
 
 ### Task 43: 기본 모델 `gpt-5.6-sol` 환원 + 댓글 모델 오버라이드
-- **상태**: 구현·검증 완료 / 커밋 승인 대기
+- **상태**: PR 제출 / 리뷰 대기 — [PR #63](https://github.com/azyu/bitbucket-codex-code-review/pull/63) (브랜치 `feat/model-override-in-codex-mention`)
 - **배경**: 선생님 요청 — 기본 모델을 `gpt-5.6-sol`로 환원하고, 대신 PR 댓글 한 줄로 이번 리뷰에만 쓸 모델을 지정할 수 있게 한다.
 - **변경**: `DEFAULTS.CODEX_MODEL`, `.env.example`, `docker-compose.yml`, README, 설정/웹훅/검증 테스트를 `gpt-5.6-sol`로 환원. `TriggerService.parseModelOverride`가 `@codex --model:<name>`(`=`·공백 구분자 포함)을 추출해 `IReviewJobData.model`로 실려 `executeCodex(…, model)`까지 흐른다.
 - **보안**: 값이 `spawn` argv의 `--model` 뒤에 그대로 들어가므로 `[A-Za-z0-9][\w.-]*`로 제한한다 — 선두 `-`를 막아 임의 codex 플래그 주입을 차단한다. allowlist는 두지 않았다(Task 28 결정 유지).

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ QUEUE_RETRY_DELAY=5000
 # Codex CLI Configuration
 CODEX_BINARY_PATH=codex
 CODEX_TIMEOUT_MS=600000
-CODEX_MODEL=gpt-6-astra
+CODEX_MODEL=gpt-5.6-sol
 CODEX_REASONING_EFFORT=medium
 OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://custom-endpoint.example.com/v1

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker compose up -d
 | 환경변수 | 설명 | 기본값 |
 |---|---|---|
 | `CODEX_BINARY_PATH` | Codex CLI 바이너리 경로 | `codex` |
-| `CODEX_MODEL` | 사용 모델 | `gpt-6-astra` |
+| `CODEX_MODEL` | 사용 모델 | `gpt-5.6-sol` |
 | `CODEX_REASONING_EFFORT` | 추론 노력도 (`none` / `low` / `medium` / `high` / `xhigh` / `max`) | `medium` |
 | `CODEX_TIMEOUT_MS` | 실행 타임아웃 (ms) | `600000` |
 | `OPENAI_API_KEY` | OpenAI API 키 (Codex CLI 인증) | - |
@@ -138,6 +138,8 @@ docker compose up -d
 > [!NOTE]
 > `auto`/`both` 모드에서 `pullrequest:updated` 이벤트도 처리됩니다. 동일 commit hash에 대한 중복 리뷰는 idempotency key로 자동 방지됩니다.
 > 동일 commit을 다시 리뷰하려면 트리거 모드와 관계없이 PR 댓글에 `@codex --force`를 입력합니다. 댓글 ID를 기준으로 웹훅 재전송은 중복 방지됩니다.
+>
+> 이번 리뷰에만 다른 모델을 쓰려면 `@codex --model:gpt-6-astra`처럼 지정합니다(`--model=`, `--model ` 형식도 동일). 지정하지 않으면 `CODEX_MODEL` 기본값을 사용하며, `--force`와 함께 쓸 때는 `@codex --force --model:gpt-6-astra` 순서로 입력합니다.
 
 ### Workspace
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 
       CODEX_BINARY_PATH: codex
       CODEX_TIMEOUT_MS: 600000
-      CODEX_MODEL: gpt-6-astra
+      CODEX_MODEL: gpt-5.6-sol
       CODEX_REASONING_EFFORT: medium
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}

--- a/src/codex/codex.service.spec.ts
+++ b/src/codex/codex.service.spec.ts
@@ -129,6 +129,25 @@ describe("CodexService", () => {
     expect(args).toContain('model_reasoning_effort="high"');
   });
 
+  // 오버라이드가 argv와 결과에 함께 반영되지 않으면 DB의 codexModel이 실제 실행한
+  // 모델과 어긋난다.
+  it("uses the per-run model argument over the configured default", async () => {
+    const child = createMockChild();
+    spawnSpy.mockReturnValue(child);
+    readFileSpy.mockResolvedValue("out");
+
+    const promise = createService({
+      "codex.model": "gpt-5.6-sol",
+    }).executeCodex("/work", "main", "review this", "gpt-6-astra");
+
+    child.emit("close", 0, null);
+    const result = await promise;
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args[args.indexOf("--model") + 1]).toBe("gpt-6-astra");
+    expect(result.model).toBe("gpt-6-astra");
+  });
+
   it.each([
     "gpt-5.6",
     "gpt-5.6-sol",

--- a/src/codex/codex.service.ts
+++ b/src/codex/codex.service.ts
@@ -42,11 +42,11 @@ export class CodexService {
     );
   }
 
-  private buildCodexArgs(outputFile: string): string[] {
+  private buildCodexArgs(outputFile: string, model: string): string[] {
     const args = [
       "exec",
       "--model",
-      this.model,
+      model,
       "--sandbox",
       "read-only",
       "--json",
@@ -188,6 +188,7 @@ export class CodexService {
     worktreePath: string,
     baseBranch: string,
     prompt: string,
+    model: string = this.model,
   ): Promise<ICodexReviewResult> {
     const startTime = Date.now();
     const outputFile = join(
@@ -196,11 +197,11 @@ export class CodexService {
     );
 
     this.logger.log(
-      `Starting codex exec in ${worktreePath}, base: ${baseBranch}, model: ${this.model}, reasoning: ${this.reasoningEffort || "default"}`,
+      `Starting codex exec in ${worktreePath}, base: ${baseBranch}, model: ${model}, reasoning: ${this.reasoningEffort || "default"}`,
     );
 
     try {
-      const args = this.buildCodexArgs(outputFile);
+      const args = this.buildCodexArgs(outputFile, model);
       const result = await this.spawnCodex(args, worktreePath, prompt);
       const durationMs = Date.now() - startTime;
 
@@ -235,7 +236,7 @@ export class CodexService {
         inputTokens: result.usage.inputTokens,
         cachedInputTokens: result.usage.cachedInputTokens,
         outputTokens: result.usage.outputTokens,
-        model: this.model,
+        model,
         reasoningEffort: this.reasoningEffort || null,
       };
     } finally {

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -18,7 +18,7 @@ describe("configuration", () => {
 
     expect(config).toEqual(
       expect.objectContaining({
-        codex: expect.objectContaining({ model: "gpt-6-astra" }),
+        codex: expect.objectContaining({ model: "gpt-5.6-sol" }),
       }),
     );
   });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -13,7 +13,7 @@ export const DEFAULTS = {
   QUEUE_RETRY_DELAY: 5000,
   CODEX_BINARY_PATH: "codex",
   CODEX_TIMEOUT_MS: 600_000,
-  CODEX_MODEL: "gpt-6-astra",
+  CODEX_MODEL: "gpt-5.6-sol",
   CODEX_REASONING_EFFORT: "medium",
   REVIEW_CUSTOM_PROMPT_FILEPATH: "",
   BITBUCKET_BASE_URL: "https://api.bitbucket.org/2.0",

--- a/src/config/validation.spec.ts
+++ b/src/config/validation.spec.ts
@@ -21,7 +21,7 @@ describe("validationSchema", () => {
       expect.objectContaining({
         PORT: 3000,
         CODEX_BINARY_PATH: "codex",
-        CODEX_MODEL: "gpt-6-astra",
+        CODEX_MODEL: "gpt-5.6-sol",
         CODEX_REASONING_EFFORT: "medium",
         BITBUCKET_REPO_TOKENS: "",
         REVIEW_TRIGGER_MODE: "mention",

--- a/src/queue/interfaces/queue.interfaces.ts
+++ b/src/queue/interfaces/queue.interfaces.ts
@@ -14,4 +14,6 @@ export interface IReviewJobData {
   readonly idempotencyKey: string;
   readonly triggerType: TriggerType;
   readonly triggerCommentId?: number;
+  /** 댓글의 `--model:<name>` 오버라이드. 없으면 설정 기본 모델 */
+  readonly model?: string;
 }

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -800,6 +800,7 @@ describe("ReviewProcessor publish results", () => {
       reviewDiff: string,
       repositorySlug: string,
       excludedChangedFiles: readonly string[] | null,
+      model?: string,
     ): Promise<ICodexReviewResult>;
   };
 
@@ -905,6 +906,30 @@ describe("ReviewProcessor publish results", () => {
         expect(prompt).toMatch(/base\s*branch|기준\s*브랜치/);
       }
     });
+    it("should forward the per-run model override to Codex", async () => {
+      mockCodexService.executeCodex.mockResolvedValue({
+        rawOutput: '{"summary":"ok","verdict":"approve","confidence":100,"findings":[]}',
+        exitCode: 0,
+        durationMs: 1,
+        inputTokens: null,
+        cachedInputTokens: null,
+        outputTokens: null,
+      });
+
+      await (processor as unknown as ReviewProcessorWithExecuteReview).executeReview(
+        "/worktree",
+        "main",
+        "+change",
+        "my-repo",
+        [],
+        "gpt-6-astra",
+      );
+
+      expect(mockCodexService.executeCodex.mock.calls[0][3]).toBe(
+        "gpt-6-astra",
+      );
+    });
+
     it("should switch to branch diff when the custom prompt makes the final inline prompt too large", async () => {
       const tmpFile = `/tmp/test-custom-prompt-${Date.now()}.txt`;
       const customPrompt = `추가 리뷰 지시사항:\n${"A".repeat(950_000)}`;

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -108,6 +108,7 @@ export class ReviewProcessor extends WorkerHost {
         reviewDiff,
         data.repositorySlug,
         excludedChangedFiles,
+        data.model,
       );
 
       // Step 3: Publish results to Bitbucket
@@ -305,6 +306,7 @@ export class ReviewProcessor extends WorkerHost {
     reviewDiff: string,
     repositorySlug: string,
     excludedChangedFiles: readonly string[] | null,
+    model?: string,
   ): Promise<ICodexReviewResult> {
     // Resolve prompt file: repoCustomPromptFilepaths[repoSlug] → customPromptFilepath
     const repoCustomPromptFilepaths =
@@ -351,6 +353,7 @@ export class ReviewProcessor extends WorkerHost {
       worktreePath,
       baseBranch,
       prompt,
+      model,
     );
 
     if (result.exitCode !== 0) {

--- a/src/webhook/trigger.service.spec.ts
+++ b/src/webhook/trigger.service.spec.ts
@@ -49,6 +49,20 @@ describe("TriggerService", () => {
     expect(service.isForceReview("@codex --forceful")).toBe(false);
   });
 
+  describe("parseModelOverride", () => {
+    it.each([
+      ["@codex --model:gpt-6-astra", "gpt-6-astra"],
+      ["@codex --model=gpt-6-astra", "gpt-6-astra"],
+      ["@codex --model gpt-5.6-sol", "gpt-5.6-sol"],
+      ["@codex --force --model:gpt-6-astra", "gpt-6-astra"],
+      ["@codex review", undefined],
+      // 값이 argv로 그대로 나가므로 플래그로 읽힐 값은 거부한다
+      ["@codex --model:--sandbox", undefined],
+    ])("%s → %s", (comment, expected) => {
+      expect(service.parseModelOverride(comment)).toBe(expected);
+    });
+  });
+
   describe("shouldAutoReview", () => {
     it.each([
       ["pullrequest:created", "auto", true],

--- a/src/webhook/trigger.service.ts
+++ b/src/webhook/trigger.service.ts
@@ -4,6 +4,9 @@ import { ServiceLogger } from "@lib/logger";
 const CODEX_MENTION_REGEX = /(?:^|\s)@codex(?:\s+review)?(?:\s|$)/i;
 const CODEX_FORCE_REGEX =
   /(?:^|\s)@codex(?:\s+review)?\s+--force(?:\s|$)/i;
+// 값은 그대로 codex CLI argv(`--model <value>`)로 넘어가므로 첫 글자를 영숫자로
+// 제한해 플래그로 해석될 여지를 없앤다.
+const CODEX_MODEL_REGEX = /--model[:=\s]\s*([A-Za-z0-9][\w.-]*)/i;
 
 @Injectable()
 export class TriggerService {
@@ -21,6 +24,11 @@ export class TriggerService {
   /** 댓글이 동일 commit 재리뷰를 강제하는지 확인 */
   isForceReview(commentRaw: string): boolean {
     return CODEX_FORCE_REGEX.test(commentRaw);
+  }
+
+  /** 댓글에 지정된 리뷰 모델(`--model:<name>`)을 추출. 없으면 undefined */
+  parseModelOverride(commentRaw: string): string | undefined {
+    return CODEX_MODEL_REGEX.exec(commentRaw)?.[1];
   }
 
   /** PR 이벤트에서 자동 리뷰를 트리거해야 하는지 확인 */

--- a/src/webhook/webhook.controller.spec.ts
+++ b/src/webhook/webhook.controller.spec.ts
@@ -31,6 +31,7 @@ describe("WebhookController", () => {
     shouldMentionReview: jest.fn(),
     hasCodexMention: jest.fn(),
     isForceReview: jest.fn(),
+    parseModelOverride: jest.fn(),
   };
   const reviewService = {
     existsByIdempotencyKey: jest.fn(),
@@ -44,7 +45,7 @@ describe("WebhookController", () => {
   };
   const configValues: Record<string, unknown> = {
     "trigger.mode": "mention",
-    "codex.model": "gpt-6-astra",
+    "codex.model": "gpt-5.6-sol",
     "codex.reasoningEffort": "high",
   };
   const configService = {
@@ -102,7 +103,7 @@ describe("WebhookController", () => {
     jest.clearAllMocks();
     Object.assign(configValues, {
       "trigger.mode": "mention",
-      "codex.model": "gpt-6-astra",
+      "codex.model": "gpt-5.6-sol",
       "codex.reasoningEffort": "high",
     });
     reviewQueue.getJob.mockResolvedValue(null);
@@ -117,6 +118,7 @@ describe("WebhookController", () => {
     triggerService.shouldMentionReview.mockReturnValue(true);
     triggerService.hasCodexMention.mockReturnValue(true);
     triggerService.isForceReview.mockReturnValue(false);
+    triggerService.parseModelOverride.mockReturnValue(undefined);
 
     controller = new WebhookController(
       reviewQueue as unknown as Queue,
@@ -163,8 +165,29 @@ describe("WebhookController", () => {
       repoSlug: "repo-a",
       pullRequestId: 17,
       parentCommentId: 321,
-      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-6-astra\n- Reasoning: high",
+      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.6-sol\n- Reasoning: high",
     });
+  });
+
+  it("forwards the comment model override to the job and the progress reply", async () => {
+    triggerService.parseModelOverride.mockReturnValue("gpt-6-astra");
+
+    await controller.handleBitbucketWebhook(
+      buildCommentWebhook("@codex --model:gpt-6-astra"),
+      "pullrequest:comment_created",
+      {},
+    );
+
+    expect(reviewQueue.add).toHaveBeenCalledWith(
+      "review",
+      expect.objectContaining({ model: "gpt-6-astra" }),
+      expect.anything(),
+    );
+    expect(bitbucketService.replyToComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-6-astra\n- Reasoning: high",
+      }),
+    );
   });
 
   it("queues an auto-triggered review and posts a top-level progress comment", async () => {
@@ -189,7 +212,7 @@ describe("WebhookController", () => {
       workspace: "workspace",
       repoSlug: "repo-a",
       pullRequestId: 17,
-      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-6-astra",
+      body: "⏳ Summary & Code Review 진행 중...\n\n- Model: gpt-5.6-sol",
     });
   });
 

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -105,15 +105,20 @@ export class WebhookController {
 
     const prPayload = this.extractPrPayload(body);
 
+    const model = this.triggerService.parseModelOverride(
+      body.comment.content.raw,
+    );
+
     const result = await this.enqueueReview(
       prPayload,
       TriggerType.MENTION,
       body.comment.id,
       forceReview,
+      model,
     );
 
     if (result.accepted) {
-      this.postInProgressReply(prPayload, body.comment.id);
+      this.postInProgressReply(prPayload, body.comment.id, model);
     }
 
     return result;
@@ -140,6 +145,7 @@ export class WebhookController {
     triggerType: TriggerType,
     triggerCommentId?: number,
     forceReview = false,
+    model?: string,
   ): Promise<{ accepted: boolean; reason?: string }> {
     const baseKey = `${prPayload.repositorySlug}:${prPayload.pullRequestId}:${prPayload.headCommitHash}`;
     const idempotencyKey =
@@ -192,6 +198,7 @@ export class WebhookController {
       idempotencyKey,
       triggerType,
       triggerCommentId,
+      model,
     };
 
     // 등록이 실패하면 run을 FAILED로 남긴다. 게시 증거 없는 FAILED는
@@ -217,8 +224,9 @@ export class WebhookController {
     return { accepted: true };
   }
 
-  private buildProgressMessage(): string {
-    const model = this.configService.getOrThrow<string>("codex.model");
+  private buildProgressMessage(modelOverride?: string): string {
+    const model =
+      modelOverride ?? this.configService.getOrThrow<string>("codex.model");
     const reasoningEffort = this.configService.get<string>(
       "codex.reasoningEffort",
       "",
@@ -233,6 +241,7 @@ export class WebhookController {
   private postInProgressReply(
     prPayload: IWebhookPrPayload,
     parentCommentId: number,
+    model?: string,
   ): void {
     this.bitbucketService
       .replyToComment({
@@ -240,7 +249,7 @@ export class WebhookController {
         repoSlug: prPayload.repositorySlug,
         pullRequestId: prPayload.pullRequestId,
         parentCommentId,
-        body: this.buildProgressMessage(),
+        body: this.buildProgressMessage(model),
       })
       .catch((err) => {
         this.logger.error(


### PR DESCRIPTION
## 요약

- 기본 리뷰 모델을 `gpt-6-astra` → `gpt-5.6-sol`로 환원
- PR 댓글에서 이번 리뷰에만 쓸 모델을 지정하는 `@codex --model:<name>` 지원 추가

## 변경 내용

### 기본 모델 환원
`src/config/configuration.ts`의 `DEFAULTS.CODEX_MODEL`, `.env.example`, `docker-compose.yml`, `README.md`, 그리고 설정/검증/웹훅 스펙을 `gpt-5.6-sol`로 정합화. `codex.service.spec.ts`의 `gpt-6-astra`는 명시적 모델 전달 테스트라 의도적으로 유지.

### 모델 오버라이드
| 위치 | 역할 |
|---|---|
| `trigger.service.ts` | `parseModelOverride` — `--model:x` / `--model=x` / `--model x` 추출 |
| `queue.interfaces.ts` | `IReviewJobData.model?` |
| `webhook.controller.ts` | 잡 데이터 + 진행 중 코멘트(`⏳ … Model: …`)에 반영 |
| `review.processor.ts` | `executeReview(..., data.model)` |
| `codex.service.ts` | `executeCodex(..., model = this.model)` — argv·로그·결과 `model` 일괄 |

argv와 결과 `model`이 함께 움직여야 DB `codexModel`(토큰 통계 귀속)이 실제 실행 모델과 어긋나지 않는다. 진행 중 코멘트도 같은 이유로 오버라이드를 반영한다.

## 보안

오버라이드 값은 `spawn` argv의 `--model` 뒤로 그대로 들어가므로 `[A-Za-z0-9][\w.-]*`로 제한했다 — 선두 `-`를 막아 댓글로 임의 codex 플래그를 주입하는 경로를 차단한다. 모델 allowlist는 추가하지 않았다(Task 28 결정 유지).

## 검증

- `pnpm build`, `pnpm lint` (경고 0)
- `pnpm test --runInBand`: 18 suites, 280 tests 통과 (베이스라인 271 + 9)
- `pnpm test:cov`: statement 91.11%, branch 82.38%, function 83.33%, line 91.19%

## 범위 밖 / 알려진 제약

1. `CODEX_FORCE_REGEX`가 `--force`를 `@codex` 바로 뒤에서만 인식 → `@codex --model:x --force`는 force로 잡히지 않는다. `@codex --force --model:x` 순서로 써야 한다.
2. `--model:gpt-6-astra.` 처럼 문장 끝 마침표를 붙이면 값에 `.`이 포함돼 codex가 거부한다.
3. reasoning effort는 오버라이드 대상이 아니다 — 모델을 바꿔도 `CODEX_REASONING_EFFORT`가 그대로 적용된다.
4. 프로덕션 기본 모델은 tools-infra `codex-code-review/fetch-env.sh`의 `CODEX_MODEL`이 결정하므로 이 PR만으로는 바뀌지 않는다.