### PR TITLE
fix(webhook): raise json body limit to 5mb and log 413 delivery headers

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -648,3 +648,20 @@
 
 - **남긴 것**: 스모크는 SDK 생성·기동·Prometheus 서빙·종료까지만 증명한다. gRPC exporter 실전송과 instrumentation 14 minor 점프(express·mysql2·winston)의 스팬 정확성은 collector가 없어 검증하지 못했고, **스테이징에서 확인이 필요하다**.
 - **재발 방지**: 레인지 내 패치가 방치되면 audit 노이즈가 쌓여 진짜 신호(otel 4건)를 가린다. `renovate.json`이 이미 리포에 있으니, minor/patch 자동 머지 대상에 lockfile 갱신이 포함되는지 확인하는 것이 근본 대책이다.
+
+### 100KiB 초과 webhook payload이 413으로 조용히 유실됨
+- **상태**: ✅ 완료
+- **배경**: tools-infra가 프로덕션(i-0a694d06349d4fa92)에서 `PayloadTooLargeError`를 2026-09-08 07:18:28·07:21:50에 각 3건 관측하고, 프로덕션 엔드포인트 직접 POST로 경계가 정확히 102,400B임을 재현했다. `src/main.ts`가 body limit을 지정하지 않아 body-parser 기본값 `100kb`가 걸린 상태였다. 413은 `WebhookGuard`보다 먼저 터지므로 서명 검증·컨트롤러 로깅을 모두 우회 → 어느 repo 이벤트였는지 사후 특정 불가. Bitbucket Cloud는 재전송이 없어 해당 `@codex` 트리거는 유실된다.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| body limit 5mb 상향 | ✅ | `src/lib/body-parser.ts`의 `configureBodyParser(app)` → `app.useBodyParser("json", { limit })`. `main.ts`는 `NestFactory.create` 직후 1줄 호출 |
+| rawBody 보존 검증 | ✅ | `NestApplication.useBodyParser`가 `appOptions.rawBody`를 `getBodyParserOptions`에 그대로 넘겨 `verify: rawBodyParser`가 유지된다(코드 확인 + 150KB 서명 페이로드 202 통과로 실증) |
+| 기본 parser 중복 확인 | ✅ | `listen()` 전에 호출하면 `ExpressAdapter.isMiddlewareApplied("jsonParser")`가 참이 되어 init의 100kb parser가 등록되지 않는다. probe에서 `jsonParser` 레이어 수 = 1 확인 |
+| 413 귀속 로깅 | ✅ | 같은 함수에서 express error middleware 등록 → `err.status === 413`일 때 `content-length` / `x-event-key` / `x-hook-uuid` / `x-request-uuid`를 error 로그로 남기고 `next(err)`로 Nest 예외 처리에 그대로 넘긴다 |
+| 테스트 | ✅ | `src/lib/body-parser.spec.ts` 5케이스. 150KB+유효서명→202, 150KB+오서명→403(fail-closed 유지), 250KB→413, 413 로그 4개 헤더, 헤더 없는 probe→`unknown` 폴백. limit `200kb`로 낮춰 테스트해 5MB 전송 회피 |
+
+- **RED 확인**: `app.useBodyParser` 한 줄을 주석 처리하면 5케이스 중 3건이 실패한다(150KB가 413으로 떨어짐). 회귀를 실제로 잡는 테스트임을 확인.
+- **왜 이렇게 고쳤나**: parser 설정을 `main.ts`에 인라인하면 `bootstrap()`이 import 시점에 실행돼 테스트가 불가능하고, 테스트는 원본이 아닌 복제본을 검증하게 된다. 그래서 `@lib/body-parser`로 분리해 스펙이 실제 프로덕션 경로를 그대로 부팅한다.
+- **남긴 것**: `x-hook-uuid`는 Bitbucket 문서상 webhook 구독(=repo별) 식별자이므로 413 시점에 repo를 역추적할 실마리가 될 수 있다 — **추정이다.** 리포 어디에도 이 헤더를 다룬 코드가 없어 실제 전송 여부는 인프라가 보는 첫 실물 413 로그로 확인해야 한다. uuid→repo 매핑도 Bitbucket API 조회가 필요하고 자동화하지 않았다. limit은 env 노출 없이 5mb 하드코딩(실측 최대 PR 객체 89,770B 대비 여유 충분).
+- **인프라 쪽 남은 확인**: Caddy에 `request_body` 상한이 별도로 걸려 있지 않은지(기본값은 무제한) 확인 필요 — 그쪽이 더 낮으면 앱 상향이 무효가 된다. Caddy access log 부재는 tools-infra가 별도 처리.

--- a/src/lib/body-parser.spec.ts
+++ b/src/lib/body-parser.spec.ts
@@ -1,0 +1,152 @@
+import { Controller, HttpCode, HttpStatus, Module, Post, UseGuards } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { NestFactory } from "@nestjs/core";
+import { NestExpressApplication } from "@nestjs/platform-express";
+import { createHmac } from "crypto";
+import { configureBodyParser } from "./body-parser";
+import { WebhookGuard } from "../webhook/webhook.guard";
+
+const mockError = jest.fn();
+
+jest.mock("./logger", () => ({
+  ServiceLogger: jest.fn().mockImplementation(() => ({
+    log: jest.fn(),
+    error: mockError,
+    warn: jest.fn(),
+    debug: jest.fn(),
+    verbose: jest.fn(),
+  })),
+}));
+
+const SECRET = "test-webhook-secret";
+const REPO_SLUG = "todoone_mt02_shell";
+
+@Controller("webhooks")
+class TestWebhookController {
+  @Post("bitbucket")
+  @HttpCode(HttpStatus.ACCEPTED)
+  @UseGuards(WebhookGuard)
+  handle(): { accepted: boolean } {
+    return { accepted: true };
+  }
+}
+
+@Module({
+  controllers: [TestWebhookController],
+  providers: [
+    {
+      provide: ConfigService,
+      useValue: {
+        get: (key: string, defaultValue?: unknown) =>
+          key === "bitbucket.webhookSecret" ? SECRET : defaultValue,
+      },
+    },
+  ],
+})
+class TestModule {}
+
+/** Bitbucket-shaped payload padded to roughly `bytes` via the PR description. */
+function buildPayload(bytes: number): string {
+  const skeleton = {
+    repository: { full_name: `workspace/${REPO_SLUG}` },
+    pullrequest: { id: 8, description: "" },
+  };
+  const padding = bytes - Buffer.byteLength(JSON.stringify(skeleton));
+  skeleton.pullrequest.description = "d".repeat(Math.max(1, padding));
+  return JSON.stringify(skeleton);
+}
+
+function sign(body: string): string {
+  return `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+}
+
+describe("configureBodyParser", () => {
+  let app: NestExpressApplication;
+  let url: string;
+
+  beforeAll(async () => {
+    app = await NestFactory.create<NestExpressApplication>(TestModule, {
+      rawBody: true,
+      logger: false,
+    });
+    // Lower than production's 5mb so the oversize case stays cheap to send.
+    configureBodyParser(app, "200kb");
+    await app.listen(0);
+    url = `${await app.getUrl()}/webhooks/bitbucket`;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    mockError.mockClear();
+  });
+
+  function post(body: string, signature?: string): Promise<Response> {
+    return fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-event-key": "pullrequest:comment_created",
+        "x-hook-uuid": "hook-uuid-1234",
+        "x-request-uuid": "request-uuid-5678",
+        ...(signature ? { "x-hub-signature": signature } : {}),
+      },
+      body,
+    });
+  }
+
+  it("accepts a payload above body-parser's 100KiB default with a valid signature", async () => {
+    const body = buildPayload(150 * 1024);
+    expect(Buffer.byteLength(body)).toBeGreaterThan(102_400);
+
+    const response = await post(body, sign(body));
+
+    // 202 proves both that the default limit is gone and that `rawBody` is
+    // still populated — the guard computes its HMAC over it and fails closed.
+    expect(response.status).toBe(HttpStatus.ACCEPTED);
+    expect(await response.json()).toEqual({ accepted: true });
+  });
+
+  it("still rejects an oversized-but-signed payload with a bad signature", async () => {
+    const body = buildPayload(150 * 1024);
+
+    const response = await post(body, "sha256=deadbeef");
+
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+  });
+
+  it("falls back to \"unknown\" for headers a non-Bitbucket caller omits", async () => {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: buildPayload(250 * 1024),
+    });
+
+    expect(response.status).toBe(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(mockError.mock.calls[0][0]).toContain(
+      "x-event-key=unknown x-hook-uuid=unknown x-request-uuid=unknown",
+    );
+  });
+
+  it("rejects a payload above the configured limit with 413", async () => {
+    const response = await post(buildPayload(250 * 1024));
+
+    expect(response.status).toBe(HttpStatus.PAYLOAD_TOO_LARGE);
+  });
+
+  it("logs the Bitbucket attribution headers when a 413 is raised", async () => {
+    const body = buildPayload(250 * 1024);
+
+    await post(body, sign(body));
+
+    expect(mockError).toHaveBeenCalledTimes(1);
+    const message = mockError.mock.calls[0][0] as string;
+    expect(message).toContain("limit 200kb");
+    expect(message).toContain(`content-length=${Buffer.byteLength(body)}`);
+    expect(message).toContain("x-event-key=pullrequest:comment_created");
+    expect(message).toContain("x-hook-uuid=hook-uuid-1234");
+    expect(message).toContain("x-request-uuid=request-uuid-5678");
+  });
+});

--- a/src/lib/body-parser.ts
+++ b/src/lib/body-parser.ts
@@ -1,0 +1,46 @@
+import type { IncomingMessage } from "node:http";
+import { NestExpressApplication } from "@nestjs/platform-express";
+import { ServiceLogger } from "./logger";
+
+/**
+ * Bitbucket PR webhook payloads embed the whole `pullrequest` object, whose
+ * `description` is repeated as `rendered`/`summary` HTML. A long description
+ * alone pushes the payload past body-parser's 100KiB default, and Bitbucket
+ * Cloud never re-delivers — the `@codex` trigger is lost silently.
+ *
+ * Must be called BEFORE `app.listen()`: `useBodyParser` registers a
+ * `jsonParser` layer, which makes Nest's own init skip the default-limit one
+ * (`ExpressAdapter.isMiddlewareApplied`). The `rawBody: true` app option is
+ * still honoured, so `WebhookGuard`'s HMAC over `request.rawBody` keeps working.
+ */
+export function configureBodyParser(
+  app: NestExpressApplication,
+  limit = "5mb",
+): void {
+  const logger = new ServiceLogger("BodyParser");
+
+  app.useBodyParser("json", { limit });
+
+  // body-parser rejects oversized payloads before any guard or controller runs,
+  // so the repo slug is unrecoverable. Log the delivery headers Bitbucket is
+  // documented to send — without this the only symptom is "@codex 무반응".
+  app.use(
+    (
+      err: { status?: number },
+      req: IncomingMessage,
+      _res: unknown,
+      next: (err?: unknown) => void,
+    ) => {
+      if (err.status === 413) {
+        logger.error(
+          `Request body rejected: too large (limit ${limit}) ` +
+            `content-length=${req.headers["content-length"] ?? "unknown"} ` +
+            `x-event-key=${req.headers["x-event-key"] ?? "unknown"} ` +
+            `x-hook-uuid=${req.headers["x-hook-uuid"] ?? "unknown"} ` +
+            `x-request-uuid=${req.headers["x-request-uuid"] ?? "unknown"}`,
+        );
+      }
+      next(err);
+    },
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { NestExpressApplication } from "@nestjs/platform-express";
 import helmet from "helmet";
 import { AppModule } from "./app.module";
 import { ServiceLogger } from "@lib/logger";
+import { configureBodyParser } from "@lib/body-parser";
 import { initOpenTelemetry } from "@lib/opentelemetry";
 
 const SERVICE_NAME = "code-review";
@@ -59,6 +60,10 @@ async function bootstrap(): Promise<string> {
         : defaultHelmet(...args);
     },
   );
+
+  // After helmet so a 413 response still carries the security headers, and
+  // before listen() so Nest skips registering its default-limit json parser.
+  configureBodyParser(app);
 
   const port = process.env["PORT"]!; // Required by validation.ts
 


### PR DESCRIPTION
## 증상

프로덕션(EC2 `i-0a694d06349d4fa92`)의 app 로그에 `PayloadTooLargeError: request entity too large`가 2026-09-08 07:18:28에 3회, 07:21:50에 3회. 리뷰 실패로는 안 보이고 `ExceptionsHandler` 스택만 남는다.

## 원인

`src/main.ts`가 body limit을 어디에도 지정하지 않아 body-parser 기본값 `limit: '100kb'`가 그대로 걸려 있었다. 프로덕션 엔드포인트 직접 POST로 경계가 **정확히 102,400B**임이 재현됐다 (tools-infra 실측):

| body size | 결과 |
|---|---|
| 51,166B | 403 (`WebhookGuard` 도달) |
| 101,342B | 403 (`WebhookGuard` 도달) |
| 103,390B | **413** (guard 도달 못 함) |
| 204,766B | **413** |

Bitbucket webhook payload은 `pullrequest` 객체를 통째로 담고, `description`이 `rendered`/`summary`에 HTML로 한 번 더 들어간다. 실측 최대치는 `todoone_mt02_shell` PR #8의 PR 객체 단독 89,770B — 여기에 `repository` + `actor` + `comment`가 더 붙으면 100KiB를 넘는다.

**왜 심각한가**: Bitbucket Cloud는 webhook 재전송이 없어 100KiB 초과 `@codex` 트리거는 그대로 유실된다. 413이 guard보다 먼저 터지므로 repo slug·PR id가 로그에 하나도 안 남아, 증상이 "`@codex` 무반응" 하나뿐인 조용한 실패다.

## 변경

`src/lib/body-parser.ts` 신규 — `configureBodyParser(app, limit = "5mb")` 하나가 두 가지를 한다.

1. `app.useBodyParser("json", { limit })`
2. express error middleware로 `err.status === 413`일 때 `content-length` / `x-event-key` / `x-hook-uuid` / `x-request-uuid`를 남기고 `next(err)`로 Nest 예외 처리에 그대로 넘긴다 (응답 코드·기존 로깅 무변경)

`main.ts`는 호출 1줄. 배치 위치가 두 번 중요하다:

- **helmet `app.use` 뒤** — 앞에 두면 413의 `next(err)`가 helmet(3-arity, non-error)을 건너뛰어 보안 헤더 없이 응답이 나간다. 기존 프로덕션 순서(기본 parser가 `init()`에서 helmet 뒤에 등록됨)를 그대로 보존.
- **`listen()` 앞** — `ExpressAdapter.isMiddlewareApplied("jsonParser")`가 참이 되어 Nest init이 100kb parser를 아예 등록하지 않는다. probe에서 `jsonParser` 레이어 수 = 1 확인.

`main.ts`가 import 시점에 `bootstrap()`을 실행하므로 인라인 설정은 테스트가 불가능하다 — 테스트가 원본이 아닌 복제본을 검증하게 되므로 별도 모듈로 분리했다.

## rawBody / HMAC 검증

`NestApplication.useBodyParser`가 `appOptions.rawBody`를 `getBodyParserOptions`에 그대로 넘겨 `verify: rawBodyParser`가 유지된다 (`@nestjs/core/nest-application.js:164`, `@nestjs/platform-express/adapters/utils/get-body-parser-options.util.js`). 코드 확인에 그치지 않고 **150KB 서명 페이로드가 guard를 통과해 202를 받는 것**으로 실증했다 — 깨졌다면 서명 검증이 fail-closed라 전 repo 리뷰가 멈추는 지점이다.

## 테스트

`src/lib/body-parser.spec.ts` 5케이스. 실제 Nest 앱을 `listen(0)`으로 띄우고 `WebhookGuard`를 붙여 프로덕션 경로를 그대로 부팅한다. limit을 `200kb`로 낮춰 5MB 전송을 피했다.

| 케이스 | 기대 | 무엇을 증명하나 |
|---|---|---|
| 150KB + 유효 서명 | 202 | 100kb 기본값 제거 **AND** `rawBody`가 guard HMAC에 그대로 들어감 |
| 150KB + 오서명 | 403 | fail-closed 유지 |
| 250KB | 413 | 상한 자체는 동작 |
| 413 로그 | 4개 헤더 포함 | 귀속 가능 |
| 헤더 없는 probe | `unknown` 폴백 | 비-Bitbucket 호출에도 안 터짐 |

**RED 확인**: `app.useBodyParser` 한 줄을 주석 처리하면 5건 중 3건이 실패한다(150KB가 413으로 떨어짐). 회귀를 실제로 잡는 테스트다.

## DoD

- `pnpm build` ✅
- `pnpm lint` 경고/에러 없음 ✅
- `pnpm test` 276 통과 ✅
- 커버리지 전체 90.99% (신규 파일 stmts/lines 100%) ✅
- `.context/TASKS.md` 갱신 ✅

## 남긴 것 / 후속

- 한도는 **5mb** 하드코딩. 실측 최대 PR 객체 89,770B 대비 여유가 크고 description은 상한이 없어 1mb는 잡지 않았다. env 노출은 하지 않았다.
- `x-hook-uuid`는 Bitbucket 문서상 webhook 구독(=repo별) 식별자이므로 413 시점 repo 역추적의 실마리가 될 수 있으나 **추정이다** — 리포에 이 헤더를 다룬 코드가 없어 실물 전송 여부는 첫 413 로그로 확인해야 한다. uuid→repo 매핑도 자동화하지 않았다.
- **인프라 확인 필요**: Caddy에 `request_body` 상한이 별도로 걸려 있지 않은지(기본값 무제한). 그쪽이 더 낮으면 앱 상향이 무효다. Caddy access log 부재는 tools-infra가 별도 처리 중.
- 이 브랜치는 body limit만 담는다. 작업 트리에 있던 `Dockerfile`/`docker-compose.yml`/`docker-publish.yml`의 `GIT_COMMIT_HASH` 작업은 별도 커밋 대상으로 남겨뒀다.