### PR TITLE
feat(queue): raise review worker concurrency with per-repo worktree lock

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -648,3 +648,20 @@
 
 - **남긴 것**: 스모크는 SDK 생성·기동·Prometheus 서빙·종료까지만 증명한다. gRPC exporter 실전송과 instrumentation 14 minor 점프(express·mysql2·winston)의 스팬 정확성은 collector가 없어 검증하지 못했고, **스테이징에서 확인이 필요하다**.
 - **재발 방지**: 레인지 내 패치가 방치되면 audit 노이즈가 쌓여 진짜 신호(otel 4건)를 가린다. `renovate.json`이 이미 리포에 있으니, minor/patch 자동 머지 대상에 lockfile 갱신이 포함되는지 확인하는 것이 근본 대책이다.
+
+### 리뷰 큐가 근무 시간에 상시 밀림 — 워커 concurrency 1 해소
+- **상태**: ✅ 완료
+- **배경**: 인프라 담당이 2026-09-08 45분간 실측한 큐 상태가 `active=1 wait=3~7`로 줄지 않고 늘었다. `@Processor(REVIEW_QUEUE_NAME)`에 워커 옵션이 없어 BullMQ 기본 `concurrency: 1`로 돌았고, 리뷰 1건 중앙값이 5~6분이라 앞에 3건이 있으면 mention을 달아둔 사람이 20분 이상 기다렸다. 인스턴스는 CPUCreditBalance 576/576·CPU 2~4%·load 0.04로 완전히 유휴 — 리뷰는 CPU가 아니라 codex/Bitbucket API 대기 바운드라 동시 실행 여지가 컸다. 반면 `WORKSPACE_MAX_CONCURRENT`는 파싱·Joi 검증까지 있으면서 소비처가 0건인 죽은 설정이었다.
+- **concurrency만 올리면 안 됐던 이유**: bare repo(`repos/<slug>.git`)는 slug당 공유인데 `prepareWorktree`의 `ensureBareRepo`→`fetchLatest`→`createWorktree` 어디에도 락이 없었다. 같은 slug 두 job이 동시에 `git fetch origin +refs/heads/*:refs/heads/* --prune`을 돌리면 같은 ref lock을 다퉈 `cannot lock ref ... File exists`로 죽는다. 오늘 큐에 `lxp_services` #3404·#3405·#3406이 연달아 대기한 것처럼 같은 repo 짝은 기본 케이스다.
+
+| 서브태스크 | 상태 | 설명 |
+|-----------|------|------|
+| concurrency를 `workspace.maxConcurrent`에 연결 | ✅ | `onApplicationBootstrap`에서 `this.worker.concurrency` 세터. `@Processor` 옵션은 import 시점 고정이라 ConfigService를 못 읽고, `onModuleInit` 시점에는 `WorkerHost.worker`가 아직 없어 throw한다(BullRegistrar가 워커를 만드는 시점이 그 뒤). BullMQ run 루프는 매 회차 concurrency를 다시 읽으므로 세터가 정식 경로 |
+| slug 단위 직렬화 | ✅ | `WorkspaceService.prepareQueues: Map<slug, Promise>` 체인으로 `prepareWorktree`만 직렬화. 저장하는 쪽만 `catch`로 감싸 앞 job 실패가 뒤를 막지 않게 하고 미처리 rejection도 막았다. 소요의 대부분인 codex exec는 락 밖이라 병렬 유지 |
+| askpass 파일명 충돌 제거 | ✅ | `.askpass-${Date.now()}.sh`는 같은 ms에 시작한 두 job이 같은 경로를 쓰고 먼저 끝난 쪽의 `unlink`가 다른 쪽 인증을 깬다. slug 락은 다른 repo 짝을 못 막으므로 `randomUUID()`로 교체 |
+| `WORKSPACE_MAX_CONCURRENT` 검증 강화 | ✅ | `Joi.number().integer().min(1)` — BullMQ 세터가 거부하는 값을 부팅 시 걸러낸다 (`GIT_CLONE_TIMEOUT_MS`와 같은 관례) |
+| 테스트 (TDD RED→GREEN) | ✅ | workspace 4케이스(같은 slug 직렬 / 다른 slug 병렬 / 앞 job 실패 후 진행 / askpass 경로 유일성 — `Date.now` 고정으로 충돌을 강제) + concurrency 배선 2케이스 + 검증 3케이스, 280 tests passed |
+| `pnpm build` + `lint` + `test:cov` | ✅ | 커버리지 91.24% (기준 80%) |
+
+- **남긴 것**: `cleanupWorktree`는 락 밖에 뒀다. `worktree remove`는 ref를 건드리지 않고 admin 디렉터리가 worktree별로 분리돼 있으며, 유일한 경합(prune과 겹침)은 기존 `rm -rf` 폴백이 흡수한다. 락에 넣으면 job의 `finally`가 다른 job의 최대 300초 fetch 뒤로 밀린다. 락은 프로세스 내부이므로 워커를 여러 프로세스로 늘리면 파일 락이 필요하다(`ponytail:` 주석으로 표시).
+- **미검증**: codex `auth.json` 세션 1개로 `codex exec`를 동시 실행할 때의 토큰 갱신 경합은 코드로 확인할 수 없다. 요금제/rate limit 자체는 문제 없다는 확인을 받았으므로, 배포 후 `code_review_authentication_failures{repository,stage}` 카운터만 지켜보면 된다.

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,8 @@ BITBUCKET_WEBHOOK_SECRET=
 
 # Workspace Configuration
 WORKSPACE_BASE_PATH=/tmp/code-review-workspaces
+# 리뷰 워커의 동시 처리 건수(BullMQ concurrency). 같은 repo의 worktree 준비는
+# 내부에서 직렬화되므로 codex exec만 병렬로 돈다.
 WORKSPACE_MAX_CONCURRENT=3
 
 # Review Trigger Mode (mention | auto | both)

--- a/src/config/validation.spec.ts
+++ b/src/config/validation.spec.ts
@@ -56,6 +56,19 @@ describe("validationSchema", () => {
     },
   );
 
+  it.each([0, -1, 1.5])(
+    "rejects WORKSPACE_MAX_CONCURRENT=%s",
+    (concurrency) => {
+      // 워커 concurrency로 그대로 들어가고 BullMQ 세터가 거부한다 — 부팅 시 걸러낸다
+      const { error } = validationSchema.validate({
+        ...validEnv,
+        WORKSPACE_MAX_CONCURRENT: concurrency,
+      });
+
+      expect(error?.message).toContain("WORKSPACE_MAX_CONCURRENT");
+    },
+  );
+
   it("defaults GIT_CLONE_TIMEOUT_MS to 600000ms", () => {
     const { error, value } = validationSchema.validate(validEnv);
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -72,7 +72,11 @@ export const validationSchema = Joi.object({
     .default("")
     .custom(jsonObjectValidator("BITBUCKET_REPO_WEBHOOK_SECRETS")),
   WORKSPACE_BASE_PATH: Joi.string().default(DEFAULTS.WORKSPACE_BASE_PATH),
-  WORKSPACE_MAX_CONCURRENT: Joi.number().default(DEFAULTS.WORKSPACE_MAX_CONCURRENT),
+  // 워커 concurrency로 그대로 들어간다 — BullMQ 세터가 1 미만/비정수를 거부한다.
+  WORKSPACE_MAX_CONCURRENT: Joi.number()
+    .integer()
+    .min(1)
+    .default(DEFAULTS.WORKSPACE_MAX_CONCURRENT),
   // execFile은 음수·소수 timeout에 ERR_OUT_OF_RANGE를 던진다 — 부팅 시 걸러낸다.
   // 0(타임아웃 없음)도 허용하지 않는다: 멈춘 clone이 워커 슬롯을 영구 점유한다.
   // 2^31-1 초과는 Node 타이머가 ~1ms로 접어 타임아웃이 되레 짧아진다.

--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -19,6 +19,7 @@ import { UnrecoverableError } from "bullmq";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { initOpenTelemetry } from "../lib/opentelemetry";
+import { DEFAULTS } from "../config/configuration";
 
 jest.mock("@lib/logger", () => ({
   ServiceLogger: jest.fn().mockImplementation(() => ({
@@ -2384,5 +2385,47 @@ describe("ReviewProcessor error handling", () => {
     expect(mockReviewService.claimFailure).toHaveBeenCalled();
     expect(mockBitbucketService.replyToComment).not.toHaveBeenCalled();
     expect(mockBitbucketService.createComment).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReviewProcessor worker concurrency", () => {
+  const buildProcessor = (configValues: Record<string, unknown>) => {
+    const configService = {
+      get: jest.fn((key: string, defaultValue?: unknown) =>
+        key in configValues ? configValues[key] : defaultValue,
+      ),
+      getOrThrow: jest.fn(),
+    };
+    const processor = new ReviewProcessor(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      configService as never,
+    );
+    // WorkerHost는 BullExplorer가 채워주는 _worker를 노출한다 — 부트스트랩 시점을 흉내낸다
+    const worker = { concurrency: 1 };
+    Object.assign(processor, { _worker: worker });
+    return { processor, worker };
+  };
+
+  it("applies WORKSPACE_MAX_CONCURRENT to the worker", () => {
+    // 기본 concurrency 1이면 리뷰 1건이 도는 동안 큐가 밀린다 — 죽은 설정을 실제로 태운다
+    const { processor, worker } = buildProcessor({
+      "workspace.maxConcurrent": 4,
+    });
+
+    processor.onApplicationBootstrap();
+
+    expect(worker.concurrency).toBe(4);
+  });
+
+  it("falls back to the configured default", () => {
+    const { processor, worker } = buildProcessor({});
+
+    processor.onApplicationBootstrap();
+
+    expect(worker.concurrency).toBe(DEFAULTS.WORKSPACE_MAX_CONCURRENT);
+    expect(worker.concurrency).toBeGreaterThan(1);
   });
 });

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -1,9 +1,11 @@
 import { Processor, WorkerHost, OnWorkerEvent } from "@nestjs/bullmq";
+import { OnApplicationBootstrap } from "@nestjs/common";
 import { Job, UnrecoverableError } from "bullmq";
 import { ConfigService } from "@nestjs/config";
 import { metrics } from "@opentelemetry/api";
 import { ServiceLogger } from "@lib/logger";
 import { REVIEW_QUEUE_NAME } from "../constants/queue.constants";
+import { DEFAULTS } from "../config/configuration";
 import { IReviewJobData } from "./interfaces/queue.interfaces";
 import { ReviewRunStatus } from "../entities/review-run.entity";
 import { ReviewService } from "../review/review.service";
@@ -39,7 +41,10 @@ function authenticationFailureStage(error: Error): "api" | "git" | null {
 }
 
 @Processor(REVIEW_QUEUE_NAME)
-export class ReviewProcessor extends WorkerHost {
+export class ReviewProcessor
+  extends WorkerHost
+  implements OnApplicationBootstrap
+{
   private readonly logger = new ServiceLogger(ReviewProcessor.name);
   private readonly authenticationFailureCounter = metrics
     .getMeter("code-review")
@@ -55,6 +60,22 @@ export class ReviewProcessor extends WorkerHost {
     private readonly configService: ConfigService,
   ) {
     super();
+  }
+
+  /**
+   * BullMQ 기본 concurrency는 1이라 리뷰 1건(중앙값 5~6분)이 도는 동안 큐가 그대로 밀린다.
+   * 리뷰는 CPU가 아니라 codex/Bitbucket API 대기 바운드이므로 동시 실행으로 처리량이 늘어난다.
+   * `@Processor` 옵션은 import 시점에 고정되어 ConfigService를 못 읽으므로 세터로 넣는다.
+   * onModuleInit 시점에는 워커가 아직 없어(WorkerHost.worker가 throw) 반드시
+   * onApplicationBootstrap이어야 한다. BullMQ run 루프는 매 회차 concurrency를 다시 읽는다.
+   */
+  onApplicationBootstrap(): void {
+    const concurrency = this.configService.get<number>(
+      "workspace.maxConcurrent",
+      DEFAULTS.WORKSPACE_MAX_CONCURRENT,
+    );
+    this.worker.concurrency = concurrency;
+    this.logger.log(`Review worker concurrency set to ${concurrency}`);
   }
 
   override async process(job: Job<IReviewJobData>): Promise<void> {

--- a/src/workspace/workspace.service.spec.ts
+++ b/src/workspace/workspace.service.spec.ts
@@ -194,6 +194,149 @@ describe("WorkspaceService", () => {
     expect(existsSync(worktreePath)).toBe(true);
   }, 30_000);
 
+  describe("per-slug serialization", () => {
+    // worker concurrency > 1이면 같은 repo의 두 job이 동시에 들어온다(같은 PR의 연속 푸시,
+    // 한 repo에 몰린 PR들). bare repo는 slug당 공유이므로 두 `git fetch`가 겹치면 같은 ref
+    // lock을 다퉈 "cannot lock ref ... File exists"로 죽는다.
+    const pendingFetches: Array<() => void> = [];
+
+    /** fetch만 붙잡아두고 나머지 git 호출은 즉시 성공시킨다 */
+    const gateFetchCalls = (failFirst = false): void => {
+      execFileMock.mockImplementation(
+        (
+          _command: string,
+          args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => {
+          if (args[0] === "fetch") {
+            const isFirst = pendingFetches.length === 0;
+            pendingFetches.push(() =>
+              failFirst && isFirst
+                ? callback(new Error("cannot lock ref 'refs/heads/main'"))
+                : callback(null, { stdout: "", stderr: "" }),
+            );
+            return;
+          }
+          callback(null, { stdout: "", stderr: "" });
+        },
+      );
+    };
+
+    const params = (slug: string, headCommitHash: string) => ({
+      cloneUrl: `https://bitbucket.org/workspace/${slug}.git`,
+      repositorySlug: slug,
+      headBranch: "feature",
+      baseBranch: "main",
+      headCommitHash,
+    });
+
+    /**
+     * 진행 중인 prepareWorktree가 fetch까지 도달할 시간을 준다. fetch 전에 실제
+     * fs 작업(mkdir/writeFile)을 await하므로 setImmediate 턴으로는 스레드풀을 기다리지
+     * 못한다 — 느린 러너에서 0건으로 관측되는 위양성이 나온다. 시간 기반이라
+     * "직렬화가 없으면 이 안에 초과 fetch가 쌓인다"도 그대로 성립한다.
+     */
+    const settle = (): Promise<void> =>
+      new Promise((resolve) => setTimeout(resolve, 50));
+
+    beforeEach(() => {
+      pendingFetches.length = 0;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks(); // Date.now 스파이가 다른 테스트로 새지 않게
+    });
+
+    it("holds a second job for the same slug until the first finishes", async () => {
+      gateFetchCalls();
+
+      const first = service.prepareWorktree(params("repo-a", "aaaaaaaa1111"));
+      await settle();
+      const second = service.prepareWorktree(params("repo-a", "bbbbbbbb2222"));
+      await settle();
+
+      expect(pendingFetches).toHaveLength(1);
+
+      pendingFetches[0]!();
+      await expect(first).resolves.toMatchObject({
+        worktreePath: join(basePath, "worktrees", "repo-a-aaaaaaaa"),
+      });
+      await settle();
+
+      expect(pendingFetches).toHaveLength(2);
+      pendingFetches[1]!();
+      await expect(second).resolves.toMatchObject({
+        worktreePath: join(basePath, "worktrees", "repo-a-bbbbbbbb"),
+      });
+    });
+
+    it("runs different slugs in parallel", async () => {
+      gateFetchCalls();
+
+      const first = service.prepareWorktree(params("repo-a", "aaaaaaaa1111"));
+      await settle();
+      const second = service.prepareWorktree(params("repo-b", "bbbbbbbb2222"));
+      await settle();
+
+      expect(pendingFetches).toHaveLength(2);
+
+      pendingFetches[0]!();
+      pendingFetches[1]!();
+      await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    });
+
+    it("gives each concurrent job its own askpass script", async () => {
+      // 파일명이 Date.now()뿐이면 같은 ms에 시작한 두 job이 같은 경로를 쓰고,
+      // 먼저 끝난 쪽의 unlink가 아직 fetch 중인 쪽의 인증을 깬다.
+      jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+      configValues["bitbucket.apiToken"] = "api-token";
+      gateFetchCalls();
+
+      const first = service.prepareWorktree(params("repo-a", "aaaaaaaa1111"));
+      await settle();
+      const second = service.prepareWorktree(params("repo-b", "bbbbbbbb2222"));
+      await settle();
+
+      const askpassPaths = execFileMock.mock.calls
+        .filter((call) => (call[1] as string[])[0] === "clone")
+        .map(
+          (call) =>
+            (call[2] as { env: Record<string, string> }).env["GIT_ASKPASS"],
+        );
+
+      expect(askpassPaths).toHaveLength(2);
+      expect(askpassPaths[0]).not.toEqual(askpassPaths[1]);
+
+      pendingFetches[0]!();
+      pendingFetches[1]!();
+      await Promise.all([first, second]);
+    });
+
+    it("keeps the queue moving when the preceding job fails", async () => {
+      gateFetchCalls(true);
+
+      // rejects 매처는 await 시점에야 핸들러를 붙인다 — 먼저 catch로 받아둬야
+      // 미처리 rejection이 러너를 물지 않는다.
+      const first = service
+        .prepareWorktree(params("repo-a", "aaaaaaaa1111"))
+        .catch((err: Error) => err.message);
+      await settle();
+      const second = service.prepareWorktree(params("repo-a", "bbbbbbbb2222"));
+      await settle();
+
+      pendingFetches[0]!();
+      await expect(first).resolves.toContain("cannot lock ref");
+      await settle();
+
+      expect(pendingFetches).toHaveLength(2);
+      pendingFetches[1]!();
+      await expect(second).resolves.toMatchObject({
+        worktreePath: join(basePath, "worktrees", "repo-a-bbbbbbbb"),
+      });
+    });
+  });
+
   it("rejects repository slugs that sanitize to an empty value", async () => {
     await expect(
       service.prepareWorktree({

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ServiceLogger } from "@lib/logger";
 import { execFile } from "child_process";
+import { randomUUID } from "crypto";
 import { promisify } from "util";
 import { join, resolve } from "path";
 import { mkdir, rm, writeFile, unlink } from "fs/promises";
@@ -31,6 +32,13 @@ export class WorkspaceService {
   private readonly logger = new ServiceLogger(WorkspaceService.name);
   private readonly basePath: string;
   private readonly cloneTimeoutMs: number;
+  /**
+   * slug별 prepareWorktree 직렬화 큐. bare repo는 slug당 공유이므로 같은 repo의 두 job이
+   * 동시에 `git fetch`를 돌리면 같은 ref lock을 다퉈 "cannot lock ref ... File exists"로
+   * 죽는다. 소요의 대부분인 codex exec는 이 락 밖이라 병렬로 남는다.
+   * ponytail: 프로세스 내 락 — 워커를 여러 프로세스/노드로 늘리면 파일 락이 필요하다.
+   */
+  private readonly prepareQueues = new Map<string, Promise<unknown>>();
 
   constructor(private readonly configService: ConfigService) {
     this.basePath = this.configService.get<string>(
@@ -78,22 +86,38 @@ export class WorkspaceService {
     this.assertWithinBasePath(bareRepoPath);
     this.assertWithinBasePath(worktreePath);
 
-    const gitAuthEnv = await this.buildGitAuthEnv(params.repositorySlug);
-    try {
-      await this.ensureBareRepo(bareRepoPath, params.cloneUrl, gitAuthEnv);
-      await this.fetchLatest(bareRepoPath, gitAuthEnv);
-    } finally {
-      if (gitAuthEnv["GIT_ASKPASS"]) {
-        await unlink(gitAuthEnv["GIT_ASKPASS"]).catch(() => {});
+    return this.enqueueForSlug(safeSlug, async () => {
+      const gitAuthEnv = await this.buildGitAuthEnv(params.repositorySlug);
+      try {
+        await this.ensureBareRepo(bareRepoPath, params.cloneUrl, gitAuthEnv);
+        await this.fetchLatest(bareRepoPath, gitAuthEnv);
+      } finally {
+        if (gitAuthEnv["GIT_ASKPASS"]) {
+          await unlink(gitAuthEnv["GIT_ASKPASS"]).catch(() => {});
+        }
       }
-    }
-    await this.createWorktree(
-      bareRepoPath,
-      worktreePath,
-      params.headCommitHash,
-    );
+      await this.createWorktree(
+        bareRepoPath,
+        worktreePath,
+        params.headCommitHash,
+      );
 
-    return { worktreePath, bareRepoPath };
+      return { worktreePath, bareRepoPath };
+    });
+  }
+
+  /** 같은 slug의 작업을 앞 작업 종료 뒤로 미룬다. 앞 작업 실패가 뒤를 막지는 않는다. */
+  private enqueueForSlug<T>(slug: string, task: () => Promise<T>): Promise<T> {
+    // 저장하는 쪽은 catch로 감싸 rejection을 흡수한다 — 큐가 실패 한 건에 멈추지 않고,
+    // 미처리 rejection도 생기지 않는다. 호출자는 원본 promise를 그대로 받는다.
+    const current = (this.prepareQueues.get(slug) ?? Promise.resolve()).then(
+      task,
+    );
+    this.prepareQueues.set(
+      slug,
+      current.catch(() => {}),
+    );
+    return current;
   }
 
   /** worktree 삭제 */
@@ -333,7 +357,9 @@ export class WorkspaceService {
     user: string,
     password: string,
   ): Promise<Record<string, string>> {
-    const scriptPath = join(this.basePath, `.askpass-${Date.now()}.sh`);
+    // 동시 실행되는 job끼리 같은 파일을 쓰면 먼저 끝난 쪽의 unlink가 아직 git을
+    // 돌리는 쪽의 인증을 깬다 — 타임스탬프만으로는 같은 ms 충돌을 막지 못한다.
+    const scriptPath = join(this.basePath, `.askpass-${randomUUID()}.sh`);
     await mkdir(this.basePath, { recursive: true });
 
     // GIT_ASKPASS is invoked with a prompt arg: "Username for ..." or "Password for ..."


### PR DESCRIPTION
## 배경

근무 시간에 리뷰 큐가 구조적으로 밀렸다. 2026-09-08 인프라 실측:

```
17:06  active=1 wait=4
17:51  active=1 wait=5   (중간에 7)
17:58  active=1 wait=3
```

45분간 줄지 않고 늘었다. `@Processor(REVIEW_QUEUE_NAME)`에 워커 옵션이 없어 BullMQ 기본 `concurrency: 1`로 돌았고, 리뷰 1건 중앙값이 5~6분이라 `@codex` mention을 달아둔 사람이 20분 이상 기다렸다.

인스턴스는 완전히 유휴 상태였다 — CPUCreditBalance 576/576(3시간 평탄), CPU 평균 2.2~3.7%, load average 0.04, codex 프로세스 CPU 1.3%/RSS 170MB. 리뷰는 CPU가 아니라 codex/Bitbucket API 대기 바운드라 동시 실행 여지가 컸다.

## 변경

### 1. concurrency를 `WORKSPACE_MAX_CONCURRENT`에 연결

이 설정은 `configuration.ts:99`에서 파싱하고 `validation.ts:75`에서 Joi 검증까지 하면서 **소비처가 0건인 죽은 설정**이었다. 이번에 실제로 태웠다.

주입 위치는 `onApplicationBootstrap`의 `worker.concurrency` 세터:

- `@Processor` 옵션은 import 시점에 고정되어 ConfigService·`.env`를 못 읽는다
- `onModuleInit` 시점에는 워커가 아직 없다 (`WorkerHost.worker`가 throw — BullRegistrar가 워커를 만드는 게 그 뒤). NestJS가 모든 `onModuleInit` 후에 `onApplicationBootstrap`을 부르는 것은 라이프사이클 보장이라 모듈 선언 순서에 의존하지 않는다
- BullMQ `run()` 루프는 매 회차 `_concurrency`를 다시 읽으므로 세터가 정식 동적 변경 경로다

기본값은 기존 `3` 유지 — 인프라 `.env=3`이 env 변경 없이 그대로 라이브가 된다.

### 2. repo slug 단위 직렬화 (concurrency만 올리면 안 되는 이유)

bare repo(`repos/<slug>.git`)는 slug당 공유인데 `prepareWorktree`의 `ensureBareRepo` → `fetchLatest` → `createWorktree` 어디에도 락이 없었다. 같은 slug 두 job이 동시에 `git fetch origin +refs/heads/*:refs/heads/* --prune`을 돌리면 같은 ref lock을 다퉈 `cannot lock ref ... File exists`로 죽는다. 오늘 큐에 `lxp_services` #3404·#3405·#3406이 연달아 대기한 것처럼 **같은 repo 짝은 엣지가 아니라 기본 케이스**다.

`Map<slug, Promise>` 체인으로 `prepareWorktree`만 직렬화했다. 저장하는 쪽만 `catch`로 감싸 앞 job 실패가 뒤를 막지 않게 하고 미처리 rejection도 막았다. 소요의 대부분인 codex exec는 락 밖이라 병렬로 남는다 — **다투는 구간만 직렬, 기다리는 구간은 병렬**.

`worktree prune`도 `createWorktree` 안에 있어 락 범위에 자연히 들어갔다.

`cleanupWorktree`는 락 밖에 뒀다. `worktree remove`는 ref를 건드리지 않고 admin 디렉터리가 worktree별로 분리돼 있으며, 유일한 경합(prune과 겹침)은 기존 `rm -rf` 폴백이 흡수한다. 락에 넣으면 job의 `finally`가 다른 job의 최대 300초 fetch 뒤로 밀린다.

### 3. askpass 파일명 충돌 제거

`.askpass-${Date.now()}.sh`는 같은 ms에 시작한 두 job이 같은 경로를 쓰고, 먼저 끝난 쪽의 `unlink`가 아직 git을 돌리는 쪽의 인증을 깬다. **이 충돌은 다른 repo 짝에서도 발생하므로 slug 락이 못 막는다.** `randomUUID()`로 교체했다.

### 4. `WORKSPACE_MAX_CONCURRENT` 검증 강화

`Joi.number().integer().min(1)` — BullMQ 세터가 거부하는 값을 부팅 시 걸러낸다 (`GIT_CLONE_TIMEOUT_MS`와 같은 관례).

## 검증

TDD RED → GREEN. 소스만 되돌린 상태에서 5건 실패를 먼저 확인했다:

- 같은 slug 두 job이 동시에 fetch에 도달 (직렬화 부재)
- 두 job의 askpass 경로가 동일 (`Date.now` 고정으로 충돌 강제)
- Joi가 `0` / `-1` / `1.5`를 통과

추가 테스트 9건: workspace 4케이스(같은 slug 직렬 / 다른 slug 병렬 / 앞 job 실패 후 큐 진행 / askpass 유일성), concurrency 배선 2케이스, Joi 3케이스.

```
pnpm build   ✅
pnpm lint    ✅
pnpm test    280 passed / 18 suites
coverage     91.24% (기준 80%)
```

## 운영 주의점 (배포 시)

- 로그에 `Review worker concurrency set to 3`이 찍히는지가 배선 확인점
- **concurrency 3이면 배포 재시작이 in-flight 1건이 아니라 최대 3건을 동시에 stall시킨다.** `maxStalledCount: 1` 노출 자체는 같지만 폭발 반경이 3배 — `active`가 낮을 때 재시작하는 게 좋다
- **미검증**: `auth.json` 세션 1개로 `codex exec`를 동시 실행할 때의 토큰 갱신 경합은 코드로 확인할 수 없다. 요금제/rate limit 자체는 문제 없음을 확인받았으므로, 배포 후 `code_review_authentication_failures{repository,stage}` 카운터만 지켜보면 된다