### PR TITLE
docs: design dashboard-managed runtime settings

### DIFF
--- a/.context/PLAN.md
+++ b/.context/PLAN.md
@@ -62,7 +62,7 @@ Bearer header는 ambient credential이 아니고 CORS를 열지 않으므로 coo
 - Queue: 새 job의 retry attempts/delay
 - Worker: global concurrency
 - Workspace: git clone timeout
-- Bitbucket: global/repository API token, global/repository webhook secret
+- Bitbucket: global/repository API token, global/repository webhook secret, global legacy Basic credential pair(username + app password)
 
 repository override 우선순위:
 
@@ -94,6 +94,14 @@ PATCH에서:
 - `{ "operation": "replace", "value": "..." }`: 교체
 - `{ "operation": "clear" }`: 삭제; repository에서는 global 상속으로 복귀
 
+legacy Basic credential은 전역에서만 하나의 atomic secret으로 관리한다.
+
+- `{ "operation": "replace", "username": "...", "appPassword": "..." }`: 두 값을 함께 교체
+- `{ "operation": "clear" }`: 두 값을 함께 삭제
+- username이나 app password 한쪽만 저장·수정하는 요청은 거부
+
+GET은 `basicCredentialConfigured`만 반환한다.
+
 빈 secret, unknown key, 잘못된 scope/type/range는 저장 전에 400으로 거부한다. `expectedRevision` 불일치는 현재 redacted 문서와 함께 409를 반환하며 자동 재시도나 force overwrite는 하지 않는다.
 
 ### 6. 최초 이관과 cutover
@@ -107,6 +115,7 @@ PATCH에서:
 - webhook 검증 secret은 요청 시작 때 한 번 읽는다.
 - webhook controller는 effective 비밀 아닌 review 설정을 resolve하고 model override를 적용한 뒤 `review_runs`의 JSON snapshot으로 저장한다. OpenAI base URL은 제외한다.
 - queue attempts/backoff는 enqueue 옵션에 명시해 새 job에만 적용한다.
+- `postInProgressReply`, `postInProgressComment`, `buildProgressMessage`는 별도 `ConfigService` 조회 없이 같은 resolved review snapshot의 model/reasoning을 표시한다.
 - processor는 저장된 review snapshot과 작업 시작 시 읽은 credential snapshot을 끝까지 재사용한다.
 - OpenAI HTTPS base URL과 API key는 같은 job-start DB 읽기에서 하나의 immutable connection snapshot으로 만들고 함께 재사용한다. 서로 다른 revision의 endpoint와 key를 섞지 않는다.
 - 실행 중 설정 변경은 해당 webhook/job/Bitbucket 게시 흐름을 바꾸지 않는다.
@@ -155,6 +164,7 @@ route:
 - Codex model/reasoning/timeout/prompt를 review snapshot 인자로 전환
 - OpenAI HTTPS base URL/API key를 같은 job-start 읽기의 atomic connection snapshot 인자로 전환
 - Bitbucket/Git credential을 작업 시작 snapshot으로 전환
+- 진행 중 댓글의 model/reasoning도 review snapshot에서 렌더링하도록 `WebhookController`의 별도 `ConfigService` 조회 제거
 - clone timeout과 worker concurrency live 적용
 - Codex child env를 allowlist로 전환
 
@@ -163,6 +173,7 @@ route:
 - 잠금 화면과 memory-only key 처리
 - global/repository 설정 form
 - secret configured/inherited 표시와 replace/clear UX
+- legacy Basic credential pair의 configured 표시와 atomic replace/clear UX
 - 400/401/409/5xx 상태 처리
 
 ### Phase 4: 정리와 검증
@@ -183,7 +194,9 @@ route:
 - 최초 이관이 현재 runtime env/default의 global 값 전체와 repository prompt 본문·API token·webhook secret을 모두 보존하며 `repositorySlug`-only 항목은 명시적 workspace mapping 없이는 cutover되지 않음
 - ingress pause와 queue drain 뒤 배포되어 snapshot 없는 queued/retrying job이 새 processor에서 실행되지 않고, drain 중 기존 job은 현재 `job.data.model`을 유지
 - OpenAI base URL은 HTTPS만 허용되고 API key와 같은 job-start 읽기에서 생성된 connection snapshot이어서 새 key가 이전 endpoint와 결합되지 않음
+- 진행 중 댓글이 같은 review snapshot의 model/reasoning을 표시해 실제 job 설정과 일치
 - repository slug가 같아도 workspace가 다르면 설정/secret이 분리
+- legacy Basic credential은 username/app password를 항상 함께 replace/clear할 수 있고 GET에는 configured 여부만 노출
 - Codex child env에 dashboard/encryption/Bitbucket/DB/Redis secret이 없음
 - 여러 Pod가 같은 새 concurrency revision을 관측해 각 worker setter에 적용하고, 이미 실행 중인 job은 유지
 - bootstrap-static 설정은 대시보드에서 노출·수정되지 않음

--- a/.context/PLAN.md
+++ b/.context/PLAN.md
@@ -123,6 +123,8 @@ GET은 `basicCredentialConfigured`만 반환한다.
 - OpenAI HTTPS base URL과 API key는 같은 job-start DB 읽기에서 하나의 immutable connection snapshot으로 만들고 함께 재사용한다. 서로 다른 revision의 endpoint와 key를 섞지 않는다.
 - 실행 중 설정 변경은 해당 webhook/job/Bitbucket 게시 흐름을 바꾸지 않는다.
 - 새 webhook은 새 review 설정을, 새 job 시작은 새 credential과 OpenAI connection 설정을 사용한다.
+- worker concurrency만 live global control이며 각 Pod가 짧은 revision polling으로 DB를 읽어 자신의 `worker.concurrency` setter에 적용한다. 낮춰도 이미 실행 중인 job은 취소하지 않는다.
+
 `CodexService`는 binary path만 constructor에 유지하고 model/reasoning/timeout/prompt는 review snapshot, OpenAI HTTPS base URL/API key는 atomic job-start connection snapshot 인자로 받는다. 실행 시 CLI `-c model_provider="openai"`와 `-c openai_base_url=<validated-url>`를 함께 override하고 API key만 명시적 child env에 넣어 기존 `config.toml`의 custom provider나 endpoint가 새 key를 받지 못하게 한다. 현재 `process.env` 전체를 child에 복사하는 방식은 고정 allowlist로 바꿔 dashboard/encryption/Bitbucket/DB/Redis secret 유출을 막는다.
 
 `WorkspaceService`는 base path만 constructor에 유지하고 clone timeout과 credential을 작업 snapshot으로 받는다. repo path와 lock key도 workspace+repository 복합 식별자를 사용한다.

--- a/.context/PLAN.md
+++ b/.context/PLAN.md
@@ -82,7 +82,7 @@ repository override 우선순위:
 
 이 값들은 DB를 읽기 전 또는 프로세스/클라이언트 생성 시 필요하므로 bootstrap-static 설정이다.
 
-OpenAI base URL은 HTTPS만 허용하며 API key와 같은 job-start DB 읽기에서 하나의 connection snapshot으로 원자적으로 resolve한다. 비밀이 아닌 값이지만 webhook 시점의 review snapshot에는 넣지 않는다. Codex 실행 시 base URL은 `OPENAI_BASE_URL` 환경변수에만 의존하지 않고 CLI `-c openai_base_url=<validated-url>` override로 전달해 기존 `config.toml`보다 높은 우선순위를 보장한다.
+OpenAI base URL은 HTTPS만 허용하며 API key와 같은 job-start DB 읽기에서 하나의 connection snapshot으로 원자적으로 resolve한다. 비밀이 아닌 값이지만 webhook 시점의 review snapshot에는 넣지 않는다. Codex 실행 시 `OPENAI_BASE_URL` 환경변수에만 의존하지 않고 CLI `-c model_provider="openai"`와 `-c openai_base_url=<validated-url>`를 함께 전달해 기존 `config.toml`의 custom provider와 endpoint보다 높은 우선순위를 보장한다.
 
 ### 5. secret API 규칙
 
@@ -108,7 +108,9 @@ GET은 `basicCredentialConfigured`만 반환한다.
 
 최초 배포의 one-time importer는 현재 runtime env/default의 global 값 전체(OpenAI 연결, queue/Codex/worker/workspace/review 설정, Bitbucket API token·webhook secret·legacy username/app-password)와 repository prompt 본문·API token·webhook secret을 해당 current row로 옮긴다. `repositorySlug`만 있는 기존 항목은 workspace를 추측하지 않고 명시적인 `repositorySlug` → `workspaceSlug` mapping을 요구하며, 누락된 mapping이 있으면 cutover하지 않는다.
 
-한 번의 배포에서 webhook ingress를 잠시 멈추고 기존 queued/retrying/running job을 현재 `job.data.model`로 모두 drain한 뒤 DB migration/import와 모든 runtime consumer를 rolling 배포한다. 모든 Pod 전환과 import 성공을 확인한 후 ingress를 재개하여 snapshot 없는 기존 job이 새 processor에 들어가지 않게 한다.
+같은 migration은 `review_runs.idempotencyKey`를 workspace-qualified key가 잘리지 않는 길이로 먼저 확장한 뒤, 모든 기존 key 앞에 해당 row의 `workspaceSlug:`를 붙여 backfill한다. force suffix를 포함한 기존 key 본문은 그대로 보존하고 unique index가 새 workspace-qualified key를 강제해야 한다.
+
+한 번의 배포에서 webhook ingress를 잠시 멈추고 기존 queued/retrying/running job을 현재 `job.data.model`로 모두 drain한다. 이어 각 legacy key에 대해 pre-cutover raw ID와 `review-${base64url(legacyKey)}` ID를 명시적으로 제거하고 queue에 실행 가능하거나 복구 가능한 job이 없음을 확인한 뒤 DB migration/import와 모든 runtime consumer를 rolling 배포한다. 모든 Pod 전환과 import 성공을 확인한 후 ingress를 재개한다.
 
 ## runtime 적용 불변식
 
@@ -116,14 +118,12 @@ GET은 `basicCredentialConfigured`만 반환한다.
 - webhook controller는 effective 비밀 아닌 review 설정을 resolve하고 model override를 적용한 뒤 `review_runs`의 JSON snapshot으로 저장한다. OpenAI base URL은 제외한다.
 - queue attempts/backoff는 enqueue 옵션에 명시해 새 job에만 적용한다.
 - `postInProgressReply`, `postInProgressComment`, `buildProgressMessage`는 별도 `ConfigService` 조회 없이 같은 resolved review snapshot의 model/reasoning을 표시한다.
-- review lifecycle identity도 `(workspaceSlug, repositorySlug)`를 끝까지 사용한다. `enqueueReview` idempotency key와 여기서 파생되는 current/legacy stale BullMQ job ID, `supersedeActivePrReviews` predicate에 workspace를 포함한다.
+- 새 review lifecycle identity는 `(workspaceSlug, repositorySlug)`를 끝까지 사용한다. `enqueueReview` idempotency key와 여기서 파생되는 raw/base64url BullMQ job ID, `supersedeActivePrReviews` predicate에 workspace를 포함한다. 전환 중에는 새 ID 외에 pre-cutover workspace 없는 raw/base64url ID도 함께 조회·제거한다.
 - processor는 저장된 review snapshot과 작업 시작 시 읽은 credential snapshot을 끝까지 재사용한다.
 - OpenAI HTTPS base URL과 API key는 같은 job-start DB 읽기에서 하나의 immutable connection snapshot으로 만들고 함께 재사용한다. 서로 다른 revision의 endpoint와 key를 섞지 않는다.
 - 실행 중 설정 변경은 해당 webhook/job/Bitbucket 게시 흐름을 바꾸지 않는다.
 - 새 webhook은 새 review 설정을, 새 job 시작은 새 credential과 OpenAI connection 설정을 사용한다.
-- worker concurrency만 live global control이며 각 Pod가 짧은 revision polling으로 DB를 읽어 자신의 `worker.concurrency` setter에 적용한다. 낮춰도 이미 실행 중인 job은 취소하지 않는다.
-
-`CodexService`는 binary path만 constructor에 유지하고 model/reasoning/timeout/prompt는 review snapshot, OpenAI HTTPS base URL/API key는 atomic job-start connection snapshot 인자로 받는다. base URL은 검증 후 CLI `-c openai_base_url=<url>`로 override하고 API key만 명시적 child env에 넣어 기존 `config.toml` endpoint가 새 key를 받지 못하게 한다. 현재 `process.env` 전체를 child에 복사하는 방식은 고정 allowlist로 바꿔 dashboard/encryption/Bitbucket/DB/Redis secret 유출을 막는다.
+`CodexService`는 binary path만 constructor에 유지하고 model/reasoning/timeout/prompt는 review snapshot, OpenAI HTTPS base URL/API key는 atomic job-start connection snapshot 인자로 받는다. 실행 시 CLI `-c model_provider="openai"`와 `-c openai_base_url=<validated-url>`를 함께 override하고 API key만 명시적 child env에 넣어 기존 `config.toml`의 custom provider나 endpoint가 새 key를 받지 못하게 한다. 현재 `process.env` 전체를 child에 복사하는 방식은 고정 allowlist로 바꿔 dashboard/encryption/Bitbucket/DB/Redis secret 유출을 막는다.
 
 `WorkspaceService`는 base path만 constructor에 유지하고 clone timeout과 credential을 작업 snapshot으로 받는다. repo path와 lock key도 workspace+repository 복합 식별자를 사용한다.
 
@@ -159,14 +159,14 @@ route:
 
 ### Phase 2: 안전한 cutover와 runtime consumer 전환
 
-- Phase 1·2를 한 번에 배포: webhook ingress 일시 중단 → 기존 queued/retrying/running job을 현재 `job.data.model`로 drain → migration/import와 모든 consumer rolling 배포 → 전체 Pod와 import 확인 후 ingress 재개
+- Phase 1·2를 한 번에 배포: webhook ingress 일시 중단 → 기존 queued/retrying/running job을 현재 `job.data.model`로 drain → pre-cutover raw/base64url BullMQ ID 제거 및 queue empty 확인 → `review_runs.idempotencyKey` workspace prefix backfill → migration/import와 모든 consumer rolling 배포 → 전체 Pod와 import 확인 후 ingress 재개
 - webhook secret/trigger mode/queue options를 runtime settings로 전환
 - review run에 OpenAI base URL을 제외한 비밀 아닌 effective review snapshot 저장
 - Codex model/reasoning/timeout/prompt를 review snapshot 인자로 전환
 - OpenAI HTTPS base URL/API key를 같은 job-start 읽기의 atomic connection snapshot 인자로 전환
 - Bitbucket/Git credential을 작업 시작 snapshot으로 전환
 - 진행 중 댓글의 model/reasoning도 review snapshot에서 렌더링하도록 `WebhookController`의 별도 `ConfigService` 조회 제거
-- `enqueueReview` idempotency key와 파생 BullMQ job ID, `supersedeActivePrReviews` predicate를 workspace+repository identity로 전환
+- `enqueueReview` idempotency key와 파생 BullMQ job ID, `supersedeActivePrReviews` predicate를 workspace+repository identity로 전환하고 pre-cutover workspace 없는 raw/base64url ID cleanup 유지
 - clone timeout과 worker concurrency live 적용
 - Codex child env를 allowlist로 전환
 
@@ -194,12 +194,13 @@ route:
 - 저장 후 Pod 재시작 없이 다음 webhook은 새 review 설정을, 다음 job 시작은 새 credential/OpenAI connection 설정을 사용
 - 실행 중 job은 저장 전 review snapshot과 job-start credential/OpenAI connection snapshot 유지
 - 최초 이관이 현재 runtime env/default의 global 값 전체와 repository prompt 본문·API token·webhook secret을 모두 보존하며 `repositorySlug`-only 항목은 명시적 workspace mapping 없이는 cutover되지 않음
-- ingress pause와 queue drain 뒤 배포되어 snapshot 없는 queued/retrying job이 새 processor에서 실행되지 않고, drain 중 기존 job은 현재 `job.data.model`을 유지
+- ingress pause 뒤 기존 job을 drain하고 pre-cutover workspace 없는 raw/base64url BullMQ ID까지 제거한 후 queue empty를 확인하여 snapshot 없는 job이 새 processor에서 실행되지 않음
 - OpenAI base URL은 HTTPS만 허용되고 API key와 같은 job-start 읽기에서 생성된 connection snapshot이어서 새 key가 이전 endpoint와 결합되지 않음
-- Codex CLI `-c openai_base_url=<validated-url>`가 기존 `config.toml`보다 우선하여 새 API key가 이전 endpoint로 전달되지 않음
+- Codex CLI `-c model_provider="openai"`와 `-c openai_base_url=<validated-url>`가 기존 `config.toml`의 custom provider/endpoint보다 우선하여 새 API key가 다른 endpoint로 전달되지 않음
 - 진행 중 댓글이 같은 review snapshot의 model/reasoning을 표시해 실제 job 설정과 일치
 - repository slug가 같아도 workspace가 다르면 설정/secret이 분리
 - 같은 repository slug/PR/commit이라도 workspace가 다르면 idempotency·BullMQ job ID·supersede가 충돌하지 않음
+- 기존 `review_runs.idempotencyKey`가 workspace prefix로 backfill되어 같은 historical commit webhook이 새 key 형식으로 한 번 더 수용되지 않음
 - legacy Basic credential은 username/app password를 항상 함께 replace/clear할 수 있고 GET에는 configured 여부만 노출
 - Codex child env에 dashboard/encryption/Bitbucket/DB/Redis secret이 없음
 - 여러 Pod가 같은 새 concurrency revision을 관측해 각 worker setter에 적용하고, 이미 실행 중인 job은 유지

--- a/.context/PLAN.md
+++ b/.context/PLAN.md
@@ -2,127 +2,198 @@
 
 ## 목표
 
-LINE NEXT 테크블로그의 AI 코드 리뷰 플랫폼 접근법에서 가치 높은 2가지를 도입:
-1. **구조화된 리뷰 출력 포맷** — 리뷰 항목을 문제설명/문제코드/수정제안/이유로 분리
-2. **리뷰 요약 테이블** — severity별 건수 집계 테이블을 요약 코멘트에 삽입
+Secret Manager에 있던 **운영 중 변경 가능한 리뷰 설정과 연동 자격증명**을 대시보드에서 관리하고, 저장 이후 새 작업부터 Pod 재시작 없이 적용한다.
 
-## 변경 범위
+첫 배포에서 DB 마이그레이션과 설정 이관을 위해 한 번은 롤아웃이 필요하다. 이후에도 DB/Redis 접속정보, 포트처럼 프로세스 부팅 전에 필요한 설정은 Secret Manager에 남고 변경 시 재시작이 필요하다.
 
-모든 변경은 `src/queue/review.processor.ts` 단일 파일에 집중됨.
+## 결정
 
----
+### 1. 설정 소유권 seam
 
-## Task 1: 구조화된 리뷰 출력 포맷
+`RuntimeSettingsService` 하나가 다음 책임을 가진다.
 
-### 변경 사항
+- 전역 설정과 `(workspaceSlug, repositorySlug)`별 override 조회
+- 입력 검증, 전역/저장소 우선순위 해석
+- secret 암복호화와 응답 redaction
+- revision 기반 조건부 갱신
+- 한 작업에서 사용할 immutable snapshot 생성
 
-#### 1-1. `IReviewItem` 인터페이스 확장 (L12-17)
+초기 구현은 매 webhook/job 시작 시 MySQL을 한 번 읽는다. 캐시, Redis pub/sub, 설정 provider interface, 이벤트 버스는 추가하지 않는다.
 
-```typescript
-// AS-IS
-interface IReviewItem {
-  path: string;
-  line: number;
-  severity: string;
-  comment: string;
-}
+### 2. 저장 구조
 
-// TO-BE
-interface IReviewItem {
-  path: string;
-  line: number;
-  severity: "blocking" | "recommended" | "suggestion" | "tech-debt";
-  description: string;      // 문제 설명
-  problemCode?: string;      // 문제 코드 인용
-  suggestedFix?: string;     // 수정 제안 코드
-  reason: string;            // 왜 이게 문제인지
-}
-```
+`runtime_settings` 한 테이블을 사용한다.
 
-#### 1-2. `SEVERITY_EMOJI` 맵 업데이트 (L19-25)
+- `scopeKey`: 전역은 고정값 `global`, repository는 `repo:<workspaceSlug>/<repositorySlug>`
+- `scope`: `global` 또는 `repository`
+- `workspaceSlug`, `repositorySlug`: nullable을 쓰지 않고 전역 row에는 빈 문자열 sentinel, repository row에는 실제 복합 식별자
+- `values`: 검증된 비밀이 아닌 JSON 설정
+- `encryptedSecrets`: 해당 scope의 secret JSON 전체를 담은 AES-256-GCM envelope
+- `revision`: optimistic concurrency용 정수
+- `updatedAt`
+- primary/unique: `scopeKey`; 보조 unique `(scope, workspaceSlug, repositorySlug)`
 
-```typescript
-// AS-IS: bug, security, performance, structure, suggestion
-// TO-BE: LINE 스타일 4단계
-const SEVERITY_EMOJI: Record<string, string> = {
-  blocking: "🚫",
-  recommended: "⚠️",
-  suggestion: "💡",
-  "tech-debt": "📝",
-};
-```
+전역 row는 하나이며 repository row는 override가 있을 때만 존재한다. append-only 설정 이력과 별도 감사 테이블은 만들지 않는다. 변경 로그에는 scope, revision, 바뀐 key 이름만 남기고 값은 남기지 않는다.
 
-#### 1-3. `reviewPrompt` 업데이트 (L78-100)
+암호화 키는 `SETTINGS_ENCRYPTION_KEY` 32-byte 값으로 Secret Manager에 남긴다. 매 저장마다 12-byte random IV를 쓰고 scope와 repository identity를 AAD로 인증한다.
 
-- 새 JSON 스키마에 맞춰 프롬프트 수정
-- 5개 카테고리(bug/security/performance/structure/suggestion) → 4단계 severity로 전환
-- 각 항목에 description, problemCode, suggestedFix, reason 필드 요구
+### 3. 대시보드 인증
 
-#### 1-4. `parseReviewJson` 업데이트 (L270-291)
+`DASHBOARD_SECRET_KEY` 하나를 Secret Manager에서 발급한다.
 
-- 새 필수 필드 검증: `path`, `line`, `description`, `reason`
-- 선택 필드: `problemCode`, `suggestedFix`
-- `severity` 기본값: 유효하지 않은 값이면 `"suggestion"`으로 폴백
+- 최소 32 bytes, 부팅 시 필수 검증
+- `/dashboard`와 정적 JS는 공개 shell로 유지
+- 기존 조회를 포함한 모든 `/api/internal/*` route에 controller-level guard 적용
+- 클라이언트는 `Authorization: Bearer <key>` 사용
+- key는 JS closure 메모리에만 보관하고 input은 즉시 비운다
+- cookie, session, localStorage, sessionStorage, login endpoint, CSRF token은 사용하지 않는다
+- 새로고침/로그아웃/401이면 key와 화면 데이터를 지우고 polling을 중단한다
+- 잘못된 key는 항상 동일한 401을 반환하고 key/header를 로그에 남기지 않는다
 
-#### 1-5. 인라인 코멘트 포맷팅 업데이트 (L144-160)
+Bearer header는 ambient credential이 아니고 CORS를 열지 않으므로 cookie 기반 CSRF 방어는 필요 없다. 모든 내부 응답은 `Cache-Control: no-store`를 사용한다.
 
-```markdown
-🚫 **Blocking**
+### 4. 관리 대상
 
-**문제**: {description}
+대시보드에서 변경:
 
-**문제 코드**:
-```
-{problemCode}
-```
+- Codex: model, reasoning effort, timeout, custom prompt **본문**
+- OpenAI: API key, HTTPS base URL
+- Review: trigger mode
+- Queue: 새 job의 retry attempts/delay
+- Worker: global concurrency
+- Workspace: git clone timeout
+- Bitbucket: global/repository API token, global/repository webhook secret
 
-**수정 제안**:
-```
-{suggestedFix}
-```
+repository override 우선순위:
 
-**이유**: {reason}
-```
+1. PR 댓글의 model override
+2. `(workspaceSlug, repositorySlug)` 설정
+3. global 설정
+4. 코드 기본값
 
----
+대시보드에서 변경하지 않음:
 
-## Task 2: 리뷰 요약 테이블
+- DB/Redis 주소와 자격증명, pool
+- HTTP/metrics port, NODE_ENV, telemetry, service metadata
+- Codex executable/auth.json mount
+- workspace base path
+- Bitbucket API base URL
+- `DASHBOARD_SECRET_KEY`, `SETTINGS_ENCRYPTION_KEY`
 
-### 변경 사항
+이 값들은 DB를 읽기 전 또는 프로세스/클라이언트 생성 시 필요하므로 bootstrap-static 설정이다.
 
-#### 2-1. 집계 함수 추가
+OpenAI base URL은 HTTPS만 허용하며 API key와 같은 job-start DB 읽기에서 하나의 connection snapshot으로 원자적으로 resolve한다. 비밀이 아닌 값이지만 webhook 시점의 review snapshot에는 넣지 않는다.
 
-`inlineItems` 파싱 후 severity별 건수를 집계하는 헬퍼 메서드.
+### 5. secret API 규칙
 
-#### 2-2. 요약 코멘트에 테이블 삽입
+GET은 secret 값, 암호문, hash, mask 문자열을 반환하지 않고 `configured`, `source`만 반환한다.
 
-현재 summary 코멘트 본문(`📋 변경사항 요약`) 하단에 리뷰 결과 요약 테이블 추가:
+PATCH에서:
 
-```markdown
-## 📊 리뷰 결과 요약
+- 필드 생략: 유지
+- `{ "operation": "replace", "value": "..." }`: 교체
+- `{ "operation": "clear" }`: 삭제; repository에서는 global 상속으로 복귀
 
-| 분류 | 건수 |
-|------|------|
-| 🚫 Blocking Issues | N건 |
-| ⚠️ Recommended Changes | N건 |
-| 💡 Suggestions | N건 |
-| 📝 Tech Debt | N건 |
-```
+빈 secret, unknown key, 잘못된 scope/type/range는 저장 전에 400으로 거부한다. `expectedRevision` 불일치는 현재 redacted 문서와 함께 409를 반환하며 자동 재시도나 force overwrite는 하지 않는다.
 
-이 테이블은 AI 출력이 아닌 **파싱된 데이터에서 코드로 생성** (안정적).
+### 6. 최초 이관과 cutover
 
-#### 2-3. 게시 순서 조정
+최초 배포의 one-time importer는 현재 runtime env/default의 global 값 전체(OpenAI 연결, queue/Codex/worker/workspace/review 설정, Bitbucket API token·webhook secret·legacy username/app-password)와 repository prompt 본문·API token·webhook secret을 해당 current row로 옮긴다. `repositorySlug`만 있는 기존 항목은 workspace를 추측하지 않고 명시적인 `repositorySlug` → `workspaceSlug` mapping을 요구하며, 누락된 mapping이 있으면 cutover하지 않는다.
 
-현재: summary와 review를 병렬 실행 → 각각 게시
-변경: 두 결과 모두 완료된 후 summary 코멘트에 요약 테이블을 합쳐서 게시.
-(코드 흐름상 이미 `Promise.all` 이후이므로 순서 변경 불필요, 포맷팅만 추가)
+한 번의 배포에서 webhook ingress를 잠시 멈추고 기존 queued/retrying/running job을 현재 `job.data.model`로 모두 drain한 뒤 DB migration/import와 모든 runtime consumer를 rolling 배포한다. 모든 Pod 전환과 import 성공을 확인한 후 ingress를 재개하여 snapshot 없는 기존 job이 새 processor에 들어가지 않게 한다.
 
----
+## runtime 적용 불변식
 
-## 변경하지 않는 것
+- webhook 검증 secret은 요청 시작 때 한 번 읽는다.
+- webhook controller는 effective 비밀 아닌 review 설정을 resolve하고 model override를 적용한 뒤 `review_runs`의 JSON snapshot으로 저장한다. OpenAI base URL은 제외한다.
+- queue attempts/backoff는 enqueue 옵션에 명시해 새 job에만 적용한다.
+- processor는 저장된 review snapshot과 작업 시작 시 읽은 credential snapshot을 끝까지 재사용한다.
+- OpenAI HTTPS base URL과 API key는 같은 job-start DB 읽기에서 하나의 immutable connection snapshot으로 만들고 함께 재사용한다. 서로 다른 revision의 endpoint와 key를 섞지 않는다.
+- 실행 중 설정 변경은 해당 webhook/job/Bitbucket 게시 흐름을 바꾸지 않는다.
+- 새 webhook은 새 review 설정을, 새 job 시작은 새 credential과 OpenAI connection 설정을 사용한다.
+- worker concurrency만 live global control이며 각 Pod가 짧은 revision polling으로 DB를 읽어 자신의 `worker.concurrency` setter에 적용한다. 낮춰도 이미 실행 중인 job은 취소하지 않는다.
 
-- `codex.service.ts` — 변경 없음
-- `bitbucket.service.ts` — 변경 없음 (인라인 코멘트 API 그대로 사용)
-- `workspace.service.ts` — 변경 없음
-- `webhook.controller.ts` — 변경 없음
-- DB 스키마 — 변경 없음 (`reviewOutput`은 text 타입이라 새 포맷도 수용)
+`CodexService`는 binary path만 constructor에 유지하고 model/reasoning/timeout/prompt는 review snapshot, OpenAI HTTPS base URL/API key는 atomic job-start connection snapshot 인자로 받는다. 현재 `process.env` 전체를 child에 복사하는 방식은 고정 allowlist와 명시적 OpenAI 변수 주입으로 바꿔 dashboard/encryption/Bitbucket/DB/Redis secret 유출을 막는다.
+
+`WorkspaceService`는 base path만 constructor에 유지하고 clone timeout과 credential을 작업 snapshot으로 받는다. repo path와 lock key도 workspace+repository 복합 식별자를 사용한다.
+
+## 내부 interface와 route
+
+핵심 interface:
+
+- `resolveReviewSettings(identity, modelOverride?)`
+- `resolveWebhookSecret(identity)`
+- `resolveBitbucketCredentials(identity)`
+- `getSettingsDocument()`
+- `updateGlobal(dto)`
+- `updateRepository(identity, dto)`
+
+route:
+
+- `GET /api/internal/settings`
+- `PATCH /api/internal/settings/global`
+- `PATCH /api/internal/settings/repositories/:workspaceSlug/:repositorySlug`
+
+별도 delete route는 만들지 않는다. repository override는 PATCH의 `null`/`clear`로 제거하며 빈 row는 revision 충돌 방지를 위해 유지한다.
+
+## 구현 순서
+
+### Phase 1: 저장과 보호
+
+- migration/entity 및 `RuntimeSettingsService`
+- one-time importer로 현재 runtime env/default의 global 값 전체와 repository prompt 본문·API token·webhook secret을 current row에 이관
+- `repositorySlug`-only 항목의 명시적 workspace mapping 검증; 누락 시 cutover 중단
+- AES-256-GCM secret 저장과 redacted DTO
+- `DASHBOARD_SECRET_KEY` guard를 모든 internal route에 적용
+- settings GET/PATCH와 revision CAS
+
+### Phase 2: 안전한 cutover와 runtime consumer 전환
+
+- Phase 1·2를 한 번에 배포: webhook ingress 일시 중단 → 기존 queued/retrying/running job을 현재 `job.data.model`로 drain → migration/import와 모든 consumer rolling 배포 → 전체 Pod와 import 확인 후 ingress 재개
+- webhook secret/trigger mode/queue options를 runtime settings로 전환
+- review run에 OpenAI base URL을 제외한 비밀 아닌 effective review snapshot 저장
+- Codex model/reasoning/timeout/prompt를 review snapshot 인자로 전환
+- OpenAI HTTPS base URL/API key를 같은 job-start 읽기의 atomic connection snapshot 인자로 전환
+- Bitbucket/Git credential을 작업 시작 snapshot으로 전환
+- clone timeout과 worker concurrency live 적용
+- Codex child env를 allowlist로 전환
+
+### Phase 3: 대시보드
+
+- 잠금 화면과 memory-only key 처리
+- global/repository 설정 form
+- secret configured/inherited 표시와 replace/clear UX
+- 400/401/409/5xx 상태 처리
+
+### Phase 4: 정리와 검증
+
+- runtime env/filepath prompt 조회 제거
+- `.env.example`, Compose, README를 bootstrap-static 설정 중심으로 정리
+- build/lint/test/coverage와 보안 체크
+- 실제 브라우저에서 로그인, 조회, 저장, 충돌, secret redaction, 다음 job 적용 확인
+
+## 수용 기준
+
+- 인증 없거나 틀린 key로 모든 `/api/internal/*` 요청이 401
+- 올바른 key는 조회/수정 가능하고 reload 뒤 재입력 필요
+- DB의 secret column에 평문이 없고 API/로그/에러에 secret이 없음
+- 같은 revision의 동시 PATCH는 정확히 하나만 성공하고 나머지는 409
+- 저장 후 Pod 재시작 없이 다음 webhook은 새 review 설정을, 다음 job 시작은 새 credential/OpenAI connection 설정을 사용
+- 실행 중 job은 저장 전 review snapshot과 job-start credential/OpenAI connection snapshot 유지
+- 최초 이관이 현재 runtime env/default의 global 값 전체와 repository prompt 본문·API token·webhook secret을 모두 보존하며 `repositorySlug`-only 항목은 명시적 workspace mapping 없이는 cutover되지 않음
+- ingress pause와 queue drain 뒤 배포되어 snapshot 없는 queued/retrying job이 새 processor에서 실행되지 않고, drain 중 기존 job은 현재 `job.data.model`을 유지
+- OpenAI base URL은 HTTPS만 허용되고 API key와 같은 job-start 읽기에서 생성된 connection snapshot이어서 새 key가 이전 endpoint와 결합되지 않음
+- repository slug가 같아도 workspace가 다르면 설정/secret이 분리
+- Codex child env에 dashboard/encryption/Bitbucket/DB/Redis secret이 없음
+- 여러 Pod가 같은 새 concurrency revision을 관측해 각 worker setter에 적용하고, 이미 실행 중인 job은 유지
+- bootstrap-static 설정은 대시보드에서 노출·수정되지 않음
+
+## 명시적으로 생략
+
+- 사용자별 계정/RBAC/SSO
+- 세션 저장소와 CSRF token
+- 설정 변경 이력/rollback UI
+- Redis 기반 캐시 무효화
+- 실행 중 job 강제 재설정
+
+둘 이상의 운영자 식별이나 설정 감사/복구 요구가 생길 때만 계정과 append-only history를 추가한다.

--- a/.context/PLAN.md
+++ b/.context/PLAN.md
@@ -82,7 +82,7 @@ repository override 우선순위:
 
 이 값들은 DB를 읽기 전 또는 프로세스/클라이언트 생성 시 필요하므로 bootstrap-static 설정이다.
 
-OpenAI base URL은 HTTPS만 허용하며 API key와 같은 job-start DB 읽기에서 하나의 connection snapshot으로 원자적으로 resolve한다. 비밀이 아닌 값이지만 webhook 시점의 review snapshot에는 넣지 않는다.
+OpenAI base URL은 HTTPS만 허용하며 API key와 같은 job-start DB 읽기에서 하나의 connection snapshot으로 원자적으로 resolve한다. 비밀이 아닌 값이지만 webhook 시점의 review snapshot에는 넣지 않는다. Codex 실행 시 base URL은 `OPENAI_BASE_URL` 환경변수에만 의존하지 않고 CLI `-c openai_base_url=<validated-url>` override로 전달해 기존 `config.toml`보다 높은 우선순위를 보장한다.
 
 ### 5. secret API 규칙
 
@@ -116,13 +116,14 @@ GET은 `basicCredentialConfigured`만 반환한다.
 - webhook controller는 effective 비밀 아닌 review 설정을 resolve하고 model override를 적용한 뒤 `review_runs`의 JSON snapshot으로 저장한다. OpenAI base URL은 제외한다.
 - queue attempts/backoff는 enqueue 옵션에 명시해 새 job에만 적용한다.
 - `postInProgressReply`, `postInProgressComment`, `buildProgressMessage`는 별도 `ConfigService` 조회 없이 같은 resolved review snapshot의 model/reasoning을 표시한다.
+- review lifecycle identity도 `(workspaceSlug, repositorySlug)`를 끝까지 사용한다. `enqueueReview` idempotency key와 여기서 파생되는 current/legacy stale BullMQ job ID, `supersedeActivePrReviews` predicate에 workspace를 포함한다.
 - processor는 저장된 review snapshot과 작업 시작 시 읽은 credential snapshot을 끝까지 재사용한다.
 - OpenAI HTTPS base URL과 API key는 같은 job-start DB 읽기에서 하나의 immutable connection snapshot으로 만들고 함께 재사용한다. 서로 다른 revision의 endpoint와 key를 섞지 않는다.
 - 실행 중 설정 변경은 해당 webhook/job/Bitbucket 게시 흐름을 바꾸지 않는다.
 - 새 webhook은 새 review 설정을, 새 job 시작은 새 credential과 OpenAI connection 설정을 사용한다.
 - worker concurrency만 live global control이며 각 Pod가 짧은 revision polling으로 DB를 읽어 자신의 `worker.concurrency` setter에 적용한다. 낮춰도 이미 실행 중인 job은 취소하지 않는다.
 
-`CodexService`는 binary path만 constructor에 유지하고 model/reasoning/timeout/prompt는 review snapshot, OpenAI HTTPS base URL/API key는 atomic job-start connection snapshot 인자로 받는다. 현재 `process.env` 전체를 child에 복사하는 방식은 고정 allowlist와 명시적 OpenAI 변수 주입으로 바꿔 dashboard/encryption/Bitbucket/DB/Redis secret 유출을 막는다.
+`CodexService`는 binary path만 constructor에 유지하고 model/reasoning/timeout/prompt는 review snapshot, OpenAI HTTPS base URL/API key는 atomic job-start connection snapshot 인자로 받는다. base URL은 검증 후 CLI `-c openai_base_url=<url>`로 override하고 API key만 명시적 child env에 넣어 기존 `config.toml` endpoint가 새 key를 받지 못하게 한다. 현재 `process.env` 전체를 child에 복사하는 방식은 고정 allowlist로 바꿔 dashboard/encryption/Bitbucket/DB/Redis secret 유출을 막는다.
 
 `WorkspaceService`는 base path만 constructor에 유지하고 clone timeout과 credential을 작업 snapshot으로 받는다. repo path와 lock key도 workspace+repository 복합 식별자를 사용한다.
 
@@ -165,6 +166,7 @@ route:
 - OpenAI HTTPS base URL/API key를 같은 job-start 읽기의 atomic connection snapshot 인자로 전환
 - Bitbucket/Git credential을 작업 시작 snapshot으로 전환
 - 진행 중 댓글의 model/reasoning도 review snapshot에서 렌더링하도록 `WebhookController`의 별도 `ConfigService` 조회 제거
+- `enqueueReview` idempotency key와 파생 BullMQ job ID, `supersedeActivePrReviews` predicate를 workspace+repository identity로 전환
 - clone timeout과 worker concurrency live 적용
 - Codex child env를 allowlist로 전환
 
@@ -194,8 +196,10 @@ route:
 - 최초 이관이 현재 runtime env/default의 global 값 전체와 repository prompt 본문·API token·webhook secret을 모두 보존하며 `repositorySlug`-only 항목은 명시적 workspace mapping 없이는 cutover되지 않음
 - ingress pause와 queue drain 뒤 배포되어 snapshot 없는 queued/retrying job이 새 processor에서 실행되지 않고, drain 중 기존 job은 현재 `job.data.model`을 유지
 - OpenAI base URL은 HTTPS만 허용되고 API key와 같은 job-start 읽기에서 생성된 connection snapshot이어서 새 key가 이전 endpoint와 결합되지 않음
+- Codex CLI `-c openai_base_url=<validated-url>`가 기존 `config.toml`보다 우선하여 새 API key가 이전 endpoint로 전달되지 않음
 - 진행 중 댓글이 같은 review snapshot의 model/reasoning을 표시해 실제 job 설정과 일치
 - repository slug가 같아도 workspace가 다르면 설정/secret이 분리
+- 같은 repository slug/PR/commit이라도 workspace가 다르면 idempotency·BullMQ job ID·supersede가 충돌하지 않음
 - legacy Basic credential은 username/app password를 항상 함께 replace/clear할 수 있고 GET에는 configured 여부만 노출
 - Codex child env에 dashboard/encryption/Bitbucket/DB/Redis secret이 없음
 - 여러 Pod가 같은 새 concurrency revision을 관측해 각 worker setter에 적용하고, 이미 실행 중인 job은 유지

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -16,6 +16,7 @@
 - **전환 게이트**: 단일 배포 전략으로 ingress를 잠시 중단하고 기존 worker가 snapshot 없는 queued/active/delayed-retry/stalled-recoverable job을 모두 drain한 뒤 새 producer/worker를 배포하고 ingress를 재개한다. drain 완료까지 기존 `job.data.model` 처리를 유지하며 snapshot 없는 job을 새 worker에 넘기지 않는다.
 - **OpenAI 연결 불변식**: HTTPS base URL과 API key를 job 시작 시 하나의 원자적 connection snapshot으로 읽어 실행 중 고정한다. enqueue 시점의 옛 endpoint와 job 시작 시점의 새 key를 조합하지 않는다. key는 review-run 비밀 제외 snapshot이나 queue payload에 저장하지 않는다.
 - **리뷰 반영**: 진행 중 댓글의 model/reasoning도 같은 review snapshot에서 렌더링한다. legacy Bitbucket Basic credential은 전역 atomic pair로 관리하여 username/app password를 함께 replace/clear하고 GET에는 configured 여부만 노출한다.
+- **2차 리뷰 반영**: review idempotency key·파생 BullMQ job ID·supersede predicate에 workspace를 포함한다. OpenAI base URL은 CLI `-c openai_base_url=<validated-url>`로 기존 `config.toml`보다 높은 우선순위를 강제하고 API key만 명시적 child env로 전달한다.
 - **구현 계획/수용 기준**: `.context/PLAN.md` 참조. 초기 rollout/seed 이후 runtime 설정은 Pod 재시작 없이 적용된다.
 - **문서**: `.context/PLAN.md`에 구현 단계와 수용 기준을 기록하고 README에 planned runtime settings, bootstrap-static 구분, 단일 key 인증 방식을 추가했다.
 - **검증**: `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공(19 suites, 294 tests). `pnpm test:cov --runInBand` 성공(statement 91.17%, branch 82.58%, function 83.87%, line 91.26%).

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -6,7 +6,7 @@
 ## 진행 중/최근 작업
 
 ### Task 44: 대시보드 runtime 설정 관리 구조 설계
-- **상태**: 설계 완료 / 구현 대기
+- **상태**: 설계 완료 / 구현 대기 — [PR #74](https://github.com/azyu/bitbucket-codex-code-review/pull/74)
 - **배경**: Secret Manager 설정 변경마다 Pod 재시작이 필요한 운영 흐름을 줄이고, 인트라넷 대시보드에서 새 작업에 즉시 적용되는 설정 관리가 필요하다. 대시보드는 단일 shared secret key로 인증한다.
 - **결정**: MySQL `runtime_settings`의 고정 `global` scope key + `(workspaceSlug, repositorySlug)` override, revision CAS, AES-256-GCM secret envelope, DB-read-per-operation `RuntimeSettingsService`를 사용한다. nullable unique에 의존하지 않고 DB가 global singleton을 보장한다. cookie/session/RBAC/cache/event bus/append-only history는 넣지 않는다.
 - **인증**: HTTPS를 필수로 하고 `DASHBOARD_SECRET_KEY` bearer header를 메모리에만 보관하며 모든 `/api/internal/*`를 guard한다. `SETTINGS_ENCRYPTION_KEY`와 DB/Redis/포트 등 bootstrap-static 값은 Secret Manager에 유지한다.

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -1,9 +1,24 @@
 # TASKS.md
 
-> 마지막 업데이트: 2026-09-08
+> 마지막 업데이트: 2026-09-09
 
 
 ## 진행 중/최근 작업
+
+### Task 44: 대시보드 runtime 설정 관리 구조 설계
+- **상태**: 설계 완료 / 구현 대기
+- **배경**: Secret Manager 설정 변경마다 Pod 재시작이 필요한 운영 흐름을 줄이고, 인트라넷 대시보드에서 새 작업에 즉시 적용되는 설정 관리가 필요하다. 대시보드는 단일 shared secret key로 인증한다.
+- **결정**: MySQL `runtime_settings`의 고정 `global` scope key + `(workspaceSlug, repositorySlug)` override, revision CAS, AES-256-GCM secret envelope, DB-read-per-operation `RuntimeSettingsService`를 사용한다. nullable unique에 의존하지 않고 DB가 global singleton을 보장한다. cookie/session/RBAC/cache/event bus/append-only history는 넣지 않는다.
+- **인증**: HTTPS를 필수로 하고 `DASHBOARD_SECRET_KEY` bearer header를 메모리에만 보관하며 모든 `/api/internal/*`를 guard한다. `SETTINGS_ENCRYPTION_KEY`와 DB/Redis/포트 등 bootstrap-static 값은 Secret Manager에 유지한다.
+- **적용 불변식**: webhook/job 시작 시 snapshot을 만들고 실행 중에는 바꾸지 않는다. queue retry는 enqueue 옵션, worker concurrency는 Pod별 polling, Codex/Workspace/Bitbucket은 명시적 snapshot 인자로 전환한다.
+- **중요 보안 수정**: 현재 Codex child가 denylist를 제외한 `process.env` 전체를 상속한다. runtime 전환 때 고정 allowlist + 명시적 OpenAI 설정 주입으로 바꿔 dashboard/encryption/Bitbucket/DB/Redis secret 전달을 차단해야 한다.
+- **일회성 import**: 현재 runtime env/default의 global 값 전체(OpenAI 연결, queue/Codex/worker/workspace/review 설정, Bitbucket API token·webhook secret·legacy username/app-password)와 repository prompt 본문·token·webhook secret을 빠짐없이 current-row 설정으로 이관한다. repository slug만 있는 기존 항목은 cutover 전에 명시적 workspace mapping을 확정해야 하며 추측으로 배정하지 않는다.
+- **전환 게이트**: 단일 배포 전략으로 ingress를 잠시 중단하고 기존 worker가 snapshot 없는 queued/active/delayed-retry/stalled-recoverable job을 모두 drain한 뒤 새 producer/worker를 배포하고 ingress를 재개한다. drain 완료까지 기존 `job.data.model` 처리를 유지하며 snapshot 없는 job을 새 worker에 넘기지 않는다.
+- **OpenAI 연결 불변식**: HTTPS base URL과 API key를 job 시작 시 하나의 원자적 connection snapshot으로 읽어 실행 중 고정한다. enqueue 시점의 옛 endpoint와 job 시작 시점의 새 key를 조합하지 않는다. key는 review-run 비밀 제외 snapshot이나 queue payload에 저장하지 않는다.
+- **구현 계획/수용 기준**: `.context/PLAN.md` 참조. 초기 rollout/seed 이후 runtime 설정은 Pod 재시작 없이 적용된다.
+- **문서**: `.context/PLAN.md`에 구현 단계와 수용 기준을 기록하고 README에 planned runtime settings, bootstrap-static 구분, 단일 key 인증 방식을 추가했다.
+- **검증**: `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공(19 suites, 294 tests). `pnpm test:cov --runInBand` 성공(statement 91.17%, branch 82.58%, function 83.87%, line 91.26%).
+
 
 
 ### Task 43: 기본 모델 `gpt-5.6-sol` 환원 + 댓글 모델 오버라이드

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -16,7 +16,7 @@
 - **전환 게이트**: 단일 배포 전략으로 ingress를 잠시 중단하고 기존 worker가 snapshot 없는 queued/active/delayed-retry/stalled-recoverable job을 모두 drain한 뒤 새 producer/worker를 배포하고 ingress를 재개한다. drain 완료까지 기존 `job.data.model` 처리를 유지하며 snapshot 없는 job을 새 worker에 넘기지 않는다.
 - **OpenAI 연결 불변식**: HTTPS base URL과 API key를 job 시작 시 하나의 원자적 connection snapshot으로 읽어 실행 중 고정한다. enqueue 시점의 옛 endpoint와 job 시작 시점의 새 key를 조합하지 않는다. key는 review-run 비밀 제외 snapshot이나 queue payload에 저장하지 않는다.
 - **리뷰 반영**: 진행 중 댓글의 model/reasoning도 같은 review snapshot에서 렌더링한다. legacy Bitbucket Basic credential은 전역 atomic pair로 관리하여 username/app password를 함께 replace/clear하고 GET에는 configured 여부만 노출한다.
-- **2차 리뷰 반영**: review idempotency key·파생 BullMQ job ID·supersede predicate에 workspace를 포함한다. OpenAI base URL은 CLI `-c openai_base_url=<validated-url>`로 기존 `config.toml`보다 높은 우선순위를 강제하고 API key만 명시적 child env로 전달한다.
+- **2차 리뷰 반영**: 새 review idempotency key·파생 BullMQ job ID·supersede predicate에 workspace를 포함한다. cutover에서 pre-cutover workspace 없는 raw/base64url BullMQ ID를 제거하고 queue empty를 확인하며 `review_runs.idempotencyKey` 컬럼을 확장한 뒤 기존 key를 workspace prefix로 backfill한다. OpenAI 연결은 CLI `-c model_provider="openai"`와 `-c openai_base_url=<validated-url>`로 기존 `config.toml`의 custom provider/endpoint보다 높은 우선순위를 강제하고 API key만 명시적 child env로 전달한다.
 - **구현 계획/수용 기준**: `.context/PLAN.md` 참조. 초기 rollout/seed 이후 runtime 설정은 Pod 재시작 없이 적용된다.
 - **문서**: `.context/PLAN.md`에 구현 단계와 수용 기준을 기록하고 README에 planned runtime settings, bootstrap-static 구분, 단일 key 인증 방식을 추가했다.
 - **검증**: `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공(19 suites, 294 tests). `pnpm test:cov --runInBand` 성공(statement 91.17%, branch 82.58%, function 83.87%, line 91.26%).

--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -15,6 +15,7 @@
 - **일회성 import**: 현재 runtime env/default의 global 값 전체(OpenAI 연결, queue/Codex/worker/workspace/review 설정, Bitbucket API token·webhook secret·legacy username/app-password)와 repository prompt 본문·token·webhook secret을 빠짐없이 current-row 설정으로 이관한다. repository slug만 있는 기존 항목은 cutover 전에 명시적 workspace mapping을 확정해야 하며 추측으로 배정하지 않는다.
 - **전환 게이트**: 단일 배포 전략으로 ingress를 잠시 중단하고 기존 worker가 snapshot 없는 queued/active/delayed-retry/stalled-recoverable job을 모두 drain한 뒤 새 producer/worker를 배포하고 ingress를 재개한다. drain 완료까지 기존 `job.data.model` 처리를 유지하며 snapshot 없는 job을 새 worker에 넘기지 않는다.
 - **OpenAI 연결 불변식**: HTTPS base URL과 API key를 job 시작 시 하나의 원자적 connection snapshot으로 읽어 실행 중 고정한다. enqueue 시점의 옛 endpoint와 job 시작 시점의 새 key를 조합하지 않는다. key는 review-run 비밀 제외 snapshot이나 queue payload에 저장하지 않는다.
+- **리뷰 반영**: 진행 중 댓글의 model/reasoning도 같은 review snapshot에서 렌더링한다. legacy Bitbucket Basic credential은 전역 atomic pair로 관리하여 username/app password를 함께 replace/clear하고 GET에는 configured 여부만 노출한다.
 - **구현 계획/수용 기준**: `.context/PLAN.md` 참조. 초기 rollout/seed 이후 runtime 설정은 Pod 재시작 없이 적용된다.
 - **문서**: `.context/PLAN.md`에 구현 단계와 수용 기준을 기록하고 README에 planned runtime settings, bootstrap-static 구분, 단일 key 인증 방식을 추가했다.
 - **검증**: `pnpm build`, `pnpm lint`, `pnpm test --runInBand` 성공(19 suites, 294 tests). `pnpm test:cov --runInBand` 성공(statement 91.17%, branch 82.58%, function 83.87%, line 91.26%).

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ docker compose up -d
 - **인증**: HTTPS에서 단일 `DASHBOARD_SECRET_KEY`를 Bearer header로 사용하고 모든 `/api/internal/*` route를 보호
 - **secret 저장**: AES-256-GCM 암호화. 조회 API는 값 대신 configured/inherited 상태만 반환
 - **설정 일관성**: 진행 중 댓글도 job과 같은 review snapshot의 model/reasoning을 표시하며 legacy Basic username/app password는 항상 함께 교체하거나 삭제
+- **식별자/연결 안전성**: review idempotency와 supersede는 workspace+repository를 사용하고 OpenAI base URL은 Codex CLI `-c` override로 기존 `config.toml`보다 우선
 
 초기 migration/import와 기존 queue drain을 위한 rollout은 한 번 필요합니다. 전환 후 runtime 설정 변경에는 Pod 재시작이 필요하지 않습니다. 상세 설계와 수용 기준은 [`.context/PLAN.md`](.context/PLAN.md)를 참조하세요.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ docker compose up -d
 - **인증**: HTTPS에서 단일 `DASHBOARD_SECRET_KEY`를 Bearer header로 사용하고 모든 `/api/internal/*` route를 보호
 - **secret 저장**: AES-256-GCM 암호화. 조회 API는 값 대신 configured/inherited 상태만 반환
 - **설정 일관성**: 진행 중 댓글도 job과 같은 review snapshot의 model/reasoning을 표시하며 legacy Basic username/app password는 항상 함께 교체하거나 삭제
-- **식별자/연결 안전성**: review idempotency와 supersede는 workspace+repository를 사용하고 OpenAI base URL은 Codex CLI `-c` override로 기존 `config.toml`보다 우선
+- **식별자/연결 안전성**: review idempotency와 supersede는 workspace+repository를 사용하고 OpenAI 연결은 Codex CLI `-c`로 built-in provider와 base URL을 함께 강제해 기존 `config.toml`보다 우선
 
 초기 migration/import와 기존 queue drain을 위한 rollout은 한 번 필요합니다. 전환 후 runtime 설정 변경에는 Pod 재시작이 필요하지 않습니다. 상세 설계와 수용 기준은 [`.context/PLAN.md`](.context/PLAN.md)를 참조하세요.
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ docker compose up -d
 
 현재 구현은 위 설정을 환경변수에서 읽으므로 값을 바꾸면 프로세스를 다시 시작해야 합니다. 향후에는 운영 중 바꿔야 하는 설정만 MySQL-backed 대시보드 설정으로 옮깁니다.
 
-- **대시보드 관리**: Codex model/reasoning/timeout/custom prompt 본문, OpenAI API key/HTTPS base URL, trigger mode, queue retry, worker concurrency, clone timeout, Bitbucket global/repository token과 webhook secret
+- **대시보드 관리**: Codex model/reasoning/timeout/custom prompt 본문, OpenAI API key/HTTPS base URL, trigger mode, queue retry, worker concurrency, clone timeout, Bitbucket global/repository token·webhook secret과 global legacy Basic credential pair
 - **Secret Manager 유지**: DB/Redis 연결, 서버/metrics port, telemetry, Codex executable/auth.json, workspace root, `DASHBOARD_SECRET_KEY`, `SETTINGS_ENCRYPTION_KEY`
 - **적용 시점**: 새 webhook/job부터 적용하며 실행 중인 작업은 시작 시점 snapshot을 유지
 - **인증**: HTTPS에서 단일 `DASHBOARD_SECRET_KEY`를 Bearer header로 사용하고 모든 `/api/internal/*` route를 보호
 - **secret 저장**: AES-256-GCM 암호화. 조회 API는 값 대신 configured/inherited 상태만 반환
+- **설정 일관성**: 진행 중 댓글도 job과 같은 review snapshot의 model/reasoning을 표시하며 legacy Basic username/app password는 항상 함께 교체하거나 삭제
 
 초기 migration/import와 기존 queue drain을 위한 rollout은 한 번 필요합니다. 전환 후 runtime 설정 변경에는 Pod 재시작이 필요하지 않습니다. 상세 설계와 수용 기준은 [`.context/PLAN.md`](.context/PLAN.md)를 참조하세요.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ docker compose up -d
 > [!TIP]
 > 전체 설정은 [`.env.example`](.env.example) 참조.
 
+### Planned Runtime Settings
+
+현재 구현은 위 설정을 환경변수에서 읽으므로 값을 바꾸면 프로세스를 다시 시작해야 합니다. 향후에는 운영 중 바꿔야 하는 설정만 MySQL-backed 대시보드 설정으로 옮깁니다.
+
+- **대시보드 관리**: Codex model/reasoning/timeout/custom prompt 본문, OpenAI API key/HTTPS base URL, trigger mode, queue retry, worker concurrency, clone timeout, Bitbucket global/repository token과 webhook secret
+- **Secret Manager 유지**: DB/Redis 연결, 서버/metrics port, telemetry, Codex executable/auth.json, workspace root, `DASHBOARD_SECRET_KEY`, `SETTINGS_ENCRYPTION_KEY`
+- **적용 시점**: 새 webhook/job부터 적용하며 실행 중인 작업은 시작 시점 snapshot을 유지
+- **인증**: HTTPS에서 단일 `DASHBOARD_SECRET_KEY`를 Bearer header로 사용하고 모든 `/api/internal/*` route를 보호
+- **secret 저장**: AES-256-GCM 암호화. 조회 API는 값 대신 configured/inherited 상태만 반환
+
+초기 migration/import와 기존 queue drain을 위한 rollout은 한 번 필요합니다. 전환 후 runtime 설정 변경에는 Pod 재시작이 필요하지 않습니다. 상세 설계와 수용 기준은 [`.context/PLAN.md`](.context/PLAN.md)를 참조하세요.
+
 ## Security
 
 > [!IMPORTANT]
@@ -175,7 +187,7 @@ pnpm lint           # ESLint
 
 ## Internal Stats API
 
-대시보드/운영 도구용 내부 전용 endpoint입니다. 공개 ingress로 노출하지 않는 것을 전제로 합니다.
+대시보드/운영 도구용 endpoint입니다. 현재 구현에는 app-layer 인증이 없으므로 ingress에서 반드시 차단해야 합니다. 위 runtime settings 전환에서는 단일 Bearer key guard로 모든 `/api/internal/*` route를 보호합니다.
 
 | Method | Path | 설명 |
 |---|---|---|
@@ -188,7 +200,7 @@ repo 통계 응답에는 리뷰 건수, Codex/전체 소요 시간, input/cached
 
 ## Local Dashboard
 
-간단한 내장 대시보드는 `GET /dashboard` 에서 확인할 수 있습니다. 같은 origin의 `/api/internal/stats/repos`를 직접 읽어 repo별 리뷰 건수, 시간, 토큰 요약을 렌더링합니다.
+내장 대시보드는 `GET /dashboard`에서 확인할 수 있습니다. 현재는 같은 origin의 `/api/internal/stats/repos`를 직접 읽어 repo별 리뷰 건수, 시간, 토큰 요약을 렌더링합니다. runtime settings 전환 후에는 reload마다 `DASHBOARD_SECRET_KEY`를 입력하며 key는 브라우저 메모리에만 유지됩니다.
 
 ## Codex CLI 인증
 


### PR DESCRIPTION
## Summary
- define the MySQL-backed runtime settings seam and global/repository precedence
- specify single-key dashboard authentication, encrypted secret storage, snapshot semantics, and safe rollout
- document planned runtime settings and bootstrap-static exceptions in README

## Security decisions
- require HTTPS and guard every `/api/internal/*` route with `DASHBOARD_SECRET_KEY`
- encrypt runtime secrets with AES-256-GCM using `SETTINGS_ENCRYPTION_KEY`
- keep secret values out of API responses, logs, BullMQ payloads, and Codex child environments
- resolve `OPENAI_BASE_URL` and `OPENAI_API_KEY` as one atomic job-start snapshot

## Verification
- `pnpm build`
- `pnpm lint`
- `pnpm test --runInBand` (19 suites, 294 tests)
- `pnpm test:cov --runInBand` (91.17% statements, 82.58% branches, 83.87% functions, 91.26% lines)