### PR TITLE
fix: attribute production review failures

### DIFF
--- a/src/queue/review.processor.spec.ts
+++ b/src/queue/review.processor.spec.ts
@@ -20,11 +20,13 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { initOpenTelemetry } from "../lib/opentelemetry";
 import { DEFAULTS } from "../config/configuration";
+const mockLoggerError = jest.fn();
+
 
 jest.mock("@lib/logger", () => ({
   ServiceLogger: jest.fn().mockImplementation(() => ({
     log: jest.fn(),
-    error: jest.fn(),
+    error: mockLoggerError,
     warn: jest.fn(),
     debug: jest.fn(),
     verbose: jest.fn(),
@@ -1882,6 +1884,9 @@ describe("ReviewProcessor error handling", () => {
       expect(metricsBody).toContain("code_review_authentication_failures_total");
       expect(metricsBody).toContain('repository="my-repo"');
       expect(metricsBody).toContain('stage="git"');
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        "Review authentication failure: repository=my-workspace/my-repo stage=git",
+      );
       expect(rejection).toBeInstanceOf(UnrecoverableError);
       expect(mockReviewService.claimFailure).toHaveBeenCalledWith(
         1,

--- a/src/queue/review.processor.ts
+++ b/src/queue/review.processor.ts
@@ -191,6 +191,9 @@ export class ReviewProcessor
           repository: data.repositorySlug,
           stage: authFailureStage,
         });
+        this.logger.error(
+          `Review authentication failure: repository=${data.workspaceSlug}/${data.repositorySlug} stage=${authFailureStage}`,
+        );
       }
 
       // 게시 전 일시 실패이고 시도가 남았으면 FAILED 기록·실패 코멘트를 보류한다.

--- a/src/workspace/workspace.service.spec.ts
+++ b/src/workspace/workspace.service.spec.ts
@@ -561,6 +561,32 @@ describe("WorkspaceService", () => {
     expect(result.excludedChangedFiles).toBeNull();
   });
 
+  it("attributes an oversized review diff to its exact git comparison", async () => {
+    execFileMock
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(null, { stdout: "basecommit123\n", stderr: "" }),
+      )
+      .mockImplementationOnce(
+        (
+          _command: string,
+          _args: string[],
+          _options: Record<string, unknown>,
+          callback: ExecFileCallback,
+        ) => callback(new Error("stdout maxBuffer length exceeded")),
+      );
+
+    await expect(
+      service.createReviewDiff("/tmp/worktree", "develop"),
+    ).rejects.toThrow(
+      'Git command failed: git ["diff","--no-ext-diff","--find-renames","--unified=80","basecommit123..HEAD","--",".",":(exclude,glob)**/pnpm-lock.yaml",":(exclude,glob)**/package-lock.json",":(exclude,glob)**/yarn.lock",":(exclude,glob)**/bun.lockb"] (base ref "refs/heads/develop"): stdout maxBuffer length exceeded',
+    );
+  });
+
   it("throws when merge-base returns an empty commit", async () => {
     execFileMock.mockImplementation(
       (

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -149,37 +149,45 @@ export class WorkspaceService {
     baseBranch: string,
   ): Promise<IReviewDiff> {
     const baseRef = `refs/heads/${baseBranch}`;
-    const { stdout: mergeBase } = await execFileAsync(
-      "git",
-      ["merge-base", baseRef, "HEAD"],
-      {
+    const mergeBaseArgs = ["merge-base", baseRef, "HEAD"];
+    let mergeBase: string;
+    try {
+      ({ stdout: mergeBase } = await execFileAsync("git", mergeBaseArgs, {
         cwd: worktreePath,
         timeout: 30_000,
-      },
-    );
+      }));
+    } catch (err) {
+      throw new Error(
+        `Git command failed: git ${JSON.stringify(mergeBaseArgs)}: ${(err as Error).message}`,
+      );
+    }
     const baseCommit = mergeBase.trim();
     if (!baseCommit) {
       throw new Error(`Git merge-base failed for ${baseRef} and HEAD`);
     }
 
-    const { stdout } = await execFileAsync(
-      "git",
-      [
-        "diff",
-        "--no-ext-diff",
-        "--find-renames",
-        "--unified=80",
-        `${baseCommit}..HEAD`,
-        "--",
-        ".",
-        ...excludePathspecs,
-      ],
-      {
+    const diffArgs = [
+      "diff",
+      "--no-ext-diff",
+      "--find-renames",
+      "--unified=80",
+      `${baseCommit}..HEAD`,
+      "--",
+      ".",
+      ...excludePathspecs,
+    ];
+    let stdout: string;
+    try {
+      ({ stdout } = await execFileAsync("git", diffArgs, {
         cwd: worktreePath,
         timeout: 60_000,
         maxBuffer: 20 * 1024 * 1024,
-      },
-    );
+      }));
+    } catch (err) {
+      throw new Error(
+        `Git command failed: git ${JSON.stringify(diffArgs)} (base ref ${JSON.stringify(baseRef)}): ${(err as Error).message}`,
+      );
+    }
 
     const excludedChangedFiles = await this.listExcludedChangedFiles(
       worktreePath,


### PR DESCRIPTION
## 변경
- OpenTelemetry 비활성화 여부와 무관하게 인증 실패를 repository identity와 `api|git` stage로 기록
- review diff의 `git merge-base`/`git diff` 실패에 JSON-escaped argv를 추가
- diff 실패에는 resolved merge-base commit 비교와 요청된 base ref를 함께 기록

## 판단
- OTEL 활성화는 인프라 선택으로 남깁니다. 인증 실패의 최소 운영 신호는 애플리케이션 로그로 항상 제공하는 편이 견고합니다.
- 20 MiB 상한은 이번 PR에서 올리지 않습니다. 관측된 재트리거 성공과 17.7/37.6 MiB의 먼 base 결과는 상한보다 잘못된 비교 귀속을 먼저 밝혀야 함을 보여줍니다. 이 PR의 로그로 다음 발생 시 실제 base/ref를 확정할 수 있습니다.
- slug 락과 failed ZSET 동작은 변경하지 않습니다.

## 검증
- 회귀 테스트를 먼저 실패시킨 뒤 수정: 전용 인증 로그 부재, maxBuffer 실패의 git 비교 정보 부재
- `pnpm lint`
- `pnpm build`
- `pnpm test --runInBand` — 19 suites, 295 tests
- coverage — statements 91.14%, branches 82.58%, functions 83.87%, lines 91.22%

Closes #79