### PR TITLE
fix: restore supported MySQL image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       # - ~/.codex:/root/.codex:ro
 
   mysql:
-    image: mysql:26.7
+    image: mysql:8.4
     container_name: code-review-mysql
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Problem

`mysql:26.7` is not published by the official MySQL image, so a fresh `docker compose up` fails before database preparation or worker startup.

## Fix

Restore the previously supported `mysql:8.4` tag.

## Verification

- `docker manifest inspect mysql:8.4` resolves amd64 and arm64 manifests
- `docker compose config --quiet` succeeds with required secrets supplied
- `docker compose config --images` resolves `mysql:8.4`
- `pnpm lint`
- `pnpm build`
- `pnpm test --coverage --runInBand` — 23 suites, 332 tests; 92.03% statements coverage