### PR TITLE
fix(deps): declare ioredis explicitly for bullmq v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "alpinejs": "^3.17.1",
     "bullmq": "^6.0.0",
     "helmet": "^8.3.0",
+    "ioredis": "^5.11.1",
     "joi": "^18.0.0",
     "mysql2": "^3.24.3",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       helmet:
         specifier: ^8.3.0
         version: 8.3.0
+      ioredis:
+        specifier: ^5.11.1
+        version: 5.11.1
       joi:
         specifier: ^18.0.0
         version: 18.2.8
@@ -4178,8 +4181,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
 
-  '@ioredis/commands@1.10.0':
-    optional: true
+  '@ioredis/commands@1.10.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5621,8 +5623,7 @@ snapshots:
 
   clone@1.0.4: {}
 
-  cluster-key-slot@1.1.1:
-    optional: true
+  cluster-key-slot@1.1.1: {}
 
   co@4.6.0: {}
 
@@ -5727,8 +5728,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  denque@2.1.0:
-    optional: true
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -6179,7 +6179,6 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -6973,13 +6972,11 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  redis-errors@1.2.0:
-    optional: true
+  redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
-    optional: true
 
   reflect-metadata@0.2.2: {}
 
@@ -7151,8 +7148,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
-  standard-as-callback@2.1.0:
-    optional: true
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
Follow-up to #70 (bullmq 5 -> 6).

## Problem

bullmq v6 demoted `ioredis` from a direct dependency to an **optional peer**. Its release notes are explicit:

> ioredis is no longer installed as a direct dependency and is now an optional peer dependency. Redis users must install ioredis explicitly.

Nothing in `package.json` declares `ioredis`. `typeorm@0.3.31` also lists it only as an optional peer. The current lockfile still resolves `ioredis@5.11.1`, but only as a leftover from the bullmq v5 tree that Renovate updated in place — the install works by accident.

## Evidence

Copying `package.json` alone into an empty directory and resolving from scratch:

| | `bullmq` entry | `ioredis` package entry |
|---|---|---|
| before | `bullmq@6.3.4` | none |
| after | `bullmq@6.3.4(ioredis@5.11.1)` | `ioredis@5.11.1` |

So a `pnpm dedupe`, a lockfile regeneration, or any resolve that does not inherit the current tree drops `ioredis`. `Dockerfile` runs `pnpm install --prod --frozen-lockfile`, so the failure would not appear at build time — it would surface as the first Redis connection failing in production.

CI did not catch this because no spec touches a real Redis; the bullmq specs are type-level and mocked, so the green run on #70 proved type compatibility only.

## Change

- `package.json`: add `"ioredis": "^5.11.1"` to `dependencies`
- `pnpm-lock.yaml`: new importer entry, plus removal of `optional: true` across the ioredis subtree (it now installs unconditionally)

`^5.11.1` rather than `^6` — bullmq's peer range is `>=5.0.0` and this keeps the currently installed version. Renovate can propose ioredis 6 as its own decision.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm build` — pass
- `pnpm lint` — no warnings or errors
- `pnpm test` — 332 passed, 23 suites
- fresh-resolve check above re-run after the change: `bullmq@6.3.4(ioredis@5.11.1)` retained

Not verified: the production Redis version against bullmq v6's floor. The v6 BREAKING list does not raise the minimum Redis version above v5's, and production Redis is provisioned from the external infrastructure repository, which is out of reach here.

## Recurrence prevention

`709cb62` adds a **의존성 업데이트 (Renovate)** section to `AGENTS.md` recording both traps this round surfaced: that green CI on a Renovate PR proves type compatibility only, and that an optional-peer demotion hides behind a lockfile leftover until you re-resolve `package.json` from scratch.
