### PR TITLE
docs: record the Renovate green-CI trap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@ PR 본문에는 `Closes #<번호>`를 넣는다. 후속 작업은 별도 이슈�
 - [ ] GitHub Issue에 검증 결과와 상태 업데이트 완료
 - [ ] 커밋 승인 요청 → 승인 후 커밋 완료 (conventional commit 형식)
 
+## 의존성 업데이트 (Renovate)
+
+Renovate PR의 CI green은 타입 호환성만 증명한다. 테스트가 실제 Redis/MySQL을 띄우지 않으므로 런타임 동작 변경은 통과한다. major 범프는 릴리스 노트의 BREAKING 항목을 코드에 직접 대조할 것.
+
+peer dependency가 optional로 강등되는 변경은 lockfile이 이전 트리의 잔재를 유지해 정상으로 보인다. `package.json`만 빈 디렉터리에 복사해 `pnpm install --lockfile-only`로 재해석하고 패키지가 살아남는지 확인할 것 (bullmq v6 → ioredis 유실, PR #90).
+
 ## 프로젝트 개요
 
 Bitbucket PR webhook → Codex CLI 코드 리뷰 → PR 코멘트 게시하는 NestJS 워커 서비스.


### PR DESCRIPTION
Records the two traps this Renovate round surfaced, so the next round verifies rather than assumes.

This commit was originally pushed onto `fix/explicit-ioredis`, but #90 merged at `1e385e6` before the push registered, so it never reached `main`. Re-applied here on its own branch.

## Why

**Green CI is weaker evidence than it looks.** #70 (bullmq 5 → 6) passed `build` + `test`, but no spec starts a real Redis — the bullmq specs are type-level and mocked. The green run proved type compatibility and nothing about runtime behavior.

**An optional-peer demotion hides behind the lockfile.** bullmq v6 moved `ioredis` from a direct dependency to an optional peer. The lockfile kept `ioredis@5.11.1` as a leftover from the v5 tree, so the install looked healthy. Resolving `package.json` alone from an empty directory showed `bullmq@6.3.4` with no ioredis entry at all — a `pnpm dedupe` or lock regeneration would have dropped it, and `Dockerfile` runs `pnpm install --prod --frozen-lockfile`, so the failure would have surfaced only at the first Redis connection in production. Fixed in #90.

## Change

One section in `AGENTS.md`, two paragraphs: the green-CI caveat for major bumps, and the fresh-resolve check for optional-peer demotions.

Docs only — no build, lint, or test impact.
